### PR TITLE
Set a default keyword prompt for OpenAi

### DIFF
--- a/src/Command/BooksTagCommand.php
+++ b/src/Command/BooksTagCommand.php
@@ -19,6 +19,8 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 )]
 class BooksTagCommand extends Command
 {
+    public const DEFAULT_KEYWORD_PROMPT = 'Imagine you want to tag a book. Can you cite the most probable categories for the following book: {book}? Display only the results, separating each term with a newline, and return an empty string if you don\'t know. This way, your answer can be parsed.';
+
     public function __construct(private EntityManagerInterface $em)
     {
         parent::__construct();
@@ -91,7 +93,9 @@ class BooksTagCommand extends Command
             $result = explode("\n", $result);
             foreach ($result as $value) {
                 $tag = trim($value, " \n\r\t\v\0-");
-                $book->addTag($tag);
+                if ($tag !== '') {
+                    $book->addTag($tag);
+                }
             }
 
             $this->em->flush();
@@ -106,7 +110,7 @@ class BooksTagCommand extends Command
 
     private function getPrompt(Book $book, User $user): string
     {
-        $prompt = (string) $user->getBookKeywordPrompt();
+        $prompt = $user->getBookKeywordPrompt() ?? self::DEFAULT_KEYWORD_PROMPT;
 
         $bookString = '"'.$book->getTitle().'" by '.implode(' and ', $book->getAuthors());
 

--- a/src/Command/BooksTagCommand.php
+++ b/src/Command/BooksTagCommand.php
@@ -4,12 +4,13 @@ namespace App\Command;
 
 use App\Entity\Book;
 use App\Entity\User;
+use App\Suggestion\TagPrompt;
 use Doctrine\ORM\EntityManagerInterface;
-use Orhanerday\OpenAi\OpenAi;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Logger\ConsoleLogger;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
@@ -19,10 +20,10 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 )]
 class BooksTagCommand extends Command
 {
-    public const DEFAULT_KEYWORD_PROMPT = 'Imagine you want to tag a book. Can you cite the most probable categories for the following book: {book}? Display only the results, separating each term with a newline, and return an empty string if you don\'t know. This way, your answer can be parsed.';
-
-    public function __construct(private EntityManagerInterface $em)
-    {
+    public function __construct(
+        private readonly EntityManagerInterface $em,
+        private readonly TagPrompt $tagPrompt
+    ) {
         parent::__construct();
     }
 
@@ -50,8 +51,6 @@ class BooksTagCommand extends Command
             return Command::FAILURE;
         }
 
-        $open_ai = new OpenAi($user->getOpenAIKey());
-
         $qb = $this->em->getRepository(Book::class)->createQueryBuilder('book');
         $qb->andWhere('book.tags = \'[]\'');
         $books = $qb->getQuery()->getResult();
@@ -63,61 +62,16 @@ class BooksTagCommand extends Command
         }
 
         $progress = $io->createProgressBar(count($books));
+        $this->tagPrompt->setLogger(new ConsoleLogger($output));
         foreach ($books as $book) {
-            $chat = $open_ai->chat([
-                'model' => 'gpt-3.5-turbo',
-                'messages' => [
-                    [
-                        'role' => 'system',
-                        'content' => 'You are a helpful factual librarian that only refers to verifiable content to provide real answers about existing books.',
-                    ],
-                    [
-                        'role' => 'user',
-                        'content' => $this->getPrompt($book, $user),
-                    ],
-                ],
-                'temperature' => 0,
-                'max_tokens' => 4000,
-                'frequency_penalty' => 0,
-                'presence_penalty' => 0,
-            ]);
-
-            if (!is_string($chat)) {
-                $io->error('Failed to decode OpenAI response');
-                continue;
-            }
-            $d = json_decode($chat);
-            // @phpstan-ignore-next-line
-            $result = $d->choices[0]->message->content;
-
-            $result = explode("\n", $result);
-            foreach ($result as $value) {
-                $tag = trim($value, " \n\r\t\v\0-");
-                if ($tag !== '') {
-                    $book->addTag($tag);
-                }
-            }
+            $this->tagPrompt->generateTags($book, $user);
 
             $this->em->flush();
-
             $progress->advance();
         }
 
         $progress->finish();
 
         return Command::SUCCESS;
-    }
-
-    private function getPrompt(Book $book, User $user): string
-    {
-        $prompt = $user->getBookKeywordPrompt() ?? self::DEFAULT_KEYWORD_PROMPT;
-
-        $bookString = '"'.$book->getTitle().'" by '.implode(' and ', $book->getAuthors());
-
-        if ($book->getSerie() !== null) {
-            $bookString .= ' number '.$book->getSerieIndex().' in the series "'.$book->getSerie().'"';
-        }
-
-        return str_replace('{book}', $bookString, $prompt);
     }
 }

--- a/src/Controller/DefaultController.php
+++ b/src/Controller/DefaultController.php
@@ -29,7 +29,7 @@ class DefaultController extends AbstractController
 
         $tags = $bookRepository->getAllTags();
 
-        $keys = array_rand($tags, 4);
+        $keys = $tags === [] ? [] : array_rand($tags, 4);
 
         $inspiration = [];
         foreach ($keys as $key) {

--- a/src/DataFixtures/UserFixture.php
+++ b/src/DataFixtures/UserFixture.php
@@ -5,17 +5,24 @@ namespace App\DataFixtures;
 use App\Entity\User;
 use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Persistence\ObjectManager;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
 
 class UserFixture extends Fixture
 {
+    public function __construct(private readonly UserPasswordHasherInterface $passwordHasher)
+    {
+    }
+
     public const USER_REFERENCE = 'user';
+    public const USER_USERNAME = 'admin@example.com';
+    public const USER_PASSWORD = 'admin@example.com';
 
     public function load(ObjectManager $manager): void
     {
         $user = new User();
-        $user->setUsername('admin@example.com');
+        $user->setUsername(self::USER_USERNAME);
         $user->setBirthday(new \DateTimeImmutable('1990-01-01'));
-        $user->setPassword('admin@example.com');
+        $user->setPassword($this->passwordHasher->hashPassword($user, self::USER_PASSWORD));
         $user->setRoles(['ROLE_ADMIN']);
 
         $manager->persist($user);

--- a/src/Repository/BookRepository.php
+++ b/src/Repository/BookRepository.php
@@ -313,7 +313,7 @@ class BookRepository extends ServiceEntityRepository
         }
         $results = [];
         foreach ($intermediateResults as $result) {
-            foreach ($result['item'] as $item) {
+            foreach ($result['item'] ?? [] as $item) {
                 $key = ucwords(strtolower($item), Book::UCWORDS_SEPARATORS);
                 if (!array_key_exists($key, $results)) {
                     $results[$key] = [

--- a/src/Suggestion/AbstractBookPrompt.php
+++ b/src/Suggestion/AbstractBookPrompt.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Suggestion;
+
+use App\Entity\Book;
+use App\Entity\User;
+
+abstract class AbstractBookPrompt
+{
+    protected function replaceBookOccurrence(Book $book, string $prompt): string
+    {
+        $bookString = '"'.$book->getTitle().'" by '.implode(' and ', $book->getAuthors());
+
+        if ($book->getSerie() !== null) {
+            $bookString .= ' number '.$book->getSerieIndex().' in the series "'.$book->getSerie().'"';
+        }
+
+        return str_replace('{book}', $bookString, $prompt);
+    }
+
+    abstract public function getPrompt(Book $book, User $user): string;
+}

--- a/src/Suggestion/SummaryPrompt.php
+++ b/src/Suggestion/SummaryPrompt.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Suggestion;
+
+use App\Entity\Book;
+use App\Entity\User;
+
+class SummaryPrompt extends AbstractBookPrompt
+{
+    public const DEFAULT_KEYWORD_PROMPT = 'Can you write a short summary for the following book: {book}?';
+
+    public function getPrompt(Book $book, User $user): string
+    {
+        $prompt = $user->getBookKeywordPrompt() ?? self::DEFAULT_KEYWORD_PROMPT;
+
+        return $this->replaceBookOccurrence($book, $prompt);
+    }
+}

--- a/src/Suggestion/TagPrompt.php
+++ b/src/Suggestion/TagPrompt.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace App\Suggestion;
+
+use App\Entity\Book;
+use App\Entity\User;
+use Orhanerday\OpenAi\OpenAi;
+use Psr\Log\LoggerInterface;
+
+class TagPrompt extends AbstractBookPrompt
+{
+    public function __construct(private LoggerInterface $logger)
+    {
+    }
+    public const DEFAULT_KEYWORD_PROMPT = 'Imagine you want to tag a book. Can you cite the most probable categories for the following book: {book}? Display only the results, separating each term with a newline, and return an empty string if you don\'t know. This way, your answer can be parsed.';
+
+    /**
+     * @return array<string>
+     */
+    public function promptResultToTags(string $promptResult): array
+    {
+        $tags = explode("\n", $promptResult);
+        $result = [];
+        foreach ($tags as $tag) {
+            $tag = trim($tag);
+            if (str_starts_with($tag, '- ')) {
+                $tag = ltrim($tag, '- ');
+            }
+            $result[] = $tag;
+        }
+
+        return array_filter($result, fn ($tag) => $tag !== '');
+    }
+
+    public function getPrompt(Book $book, User $user): string
+    {
+        $prompt = $user->getBookKeywordPrompt() ?? self::DEFAULT_KEYWORD_PROMPT;
+
+        return $this->replaceBookOccurrence($book, $prompt);
+    }
+
+    /**
+     * @throws \InvalidArgumentException When the user has no api key
+     * @throws \Exception
+     */
+    public function generateTags(Book $book, User $user): void
+    {
+        if ($user->getOpenAIKey() === null) {
+            throw new \InvalidArgumentException('User does not have an OpenAI Key');
+        }
+
+        $open_ai = new OpenAi($user->getOpenAIKey());
+
+        $chat = $open_ai->chat([
+            'model' => 'gpt-3.5-turbo',
+            'messages' => [
+                [
+                    'role' => 'system',
+                    'content' => 'You are a helpful factual librarian that only refers to verifiable content to provide real answers about existing books.',
+                ],
+                [
+                    'role' => 'user',
+                    'content' => $this->getPrompt($book, $user),
+                ],
+            ],
+            'temperature' => 0,
+            'max_tokens' => 4000,
+            'frequency_penalty' => 0,
+            'presence_penalty' => 0,
+        ]);
+
+        if (!is_string($chat)) {
+            $this->logger->error('Failed to decode OpenAI response');
+
+            return;
+        }
+        $d = json_decode($chat);
+        // @phpstan-ignore-next-line
+        $result = $d->choices[0]->message->content;
+
+        foreach ($this->promptResultToTags($result) as $tag) {
+            $book->addTag($tag);
+        }
+    }
+
+    public function setLogger(LoggerInterface $logger): self
+    {
+        $this->logger = $logger;
+
+        return $this;
+    }
+}

--- a/tests/Suggestion/SummaryPromptTest.php
+++ b/tests/Suggestion/SummaryPromptTest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Tests\Suggestion;
+
+use App\Entity\Book;
+use App\Entity\User;
+use App\Suggestion\SummaryPrompt;
+use PHPUnit\Framework\TestCase;
+
+class SummaryPromptTest extends TestCase
+{
+
+    private function getBook(): Book
+    {
+        $book = new Book();
+        $book->setTitle('The Hobbit');
+        $book->setAuthors(['J.R.R. Tolkien']);
+        $book->setSerie('The Lord of the Rings');
+        $book->setSerieIndex(1);
+        return $book;
+    }
+    public function testGetPrompt(): void
+    {
+        $book = $this->getBook();
+
+        $user = new User();
+        $user->setOpenAIKey('test');
+        $user->setBookSummaryPrompt(null);
+        $summaryPrompt = new SummaryPrompt();
+        $prompt = $summaryPrompt->getPrompt($book, $user);
+        self::assertStringContainsString($book->getTitle(), $prompt);
+        self::assertStringContainsString('in the series', $prompt);
+    }
+
+    public function testUserPrompt(): void{
+        $book = $this->getBook();
+
+        $user = new User();
+        $user->setOpenAIKey('test');
+        $user->setBookSummaryPrompt('Can you write a short summary for the following book: {book}?');
+
+        $summaryPrompt = new SummaryPrompt();
+        $prompt = $summaryPrompt->getPrompt($book, $user);
+        self::assertStringContainsString('Can you write a short summary for the following book: "The Hobbit" by J.R.R. Tolkien number 1 in the series "The Lord of the Rings"?', $prompt);
+    }
+}

--- a/tests/Suggestion/TagPromptTest.php
+++ b/tests/Suggestion/TagPromptTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Tests\Suggestion;
+
+use App\Entity\Book;
+use App\Entity\User;
+use App\Suggestion\TagPrompt;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+
+class TagPromptTest extends TestCase
+{
+    public function testGetPrompt(): void
+    {
+        $book = new Book();
+        $book->setTitle('The Hobbit');
+        $book->setAuthors(['J.R.R. Tolkien']);
+        $book->setSerie('The Lord of the Rings');
+        $book->setSerieIndex(1);
+
+        $user = new User();
+        $user->setOpenAIKey('test');
+
+        $summaryPrompt = new TagPrompt(new NullLogger());
+        $prompt = $summaryPrompt->getPrompt($book, $user);
+        self::assertStringContainsString($book->getTitle(), $prompt);
+        self::assertStringContainsString('in the series', $prompt);
+    }
+
+    public function testPromptResultToTags(): void
+    {
+        $tagPrompt = new TagPrompt(new NullLogger());
+        $tags = $tagPrompt->promptResultToTags("- fantasy\n- adventure\n - classic");
+        self::assertSame(['fantasy', 'adventure', 'classic'], $tags);
+    }
+}

--- a/tests/Twig/Components/ChatGPTSuggestionTest.php
+++ b/tests/Twig/Components/ChatGPTSuggestionTest.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace App\Tests\Twig\Components;
+
+use App\Entity\Book;
+use App\Entity\User;
+use App\Repository\BookRepository;
+use App\Repository\UserRepository;
+use App\Suggestion\SummaryPrompt;
+use App\Suggestion\TagPrompt;
+use App\Twig\Components\ChatGPTSuggestion;
+use App\DataFixtures\BookFixture;
+use App\DataFixtures\UserFixture;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\UX\LiveComponent\Test\InteractsWithLiveComponents;
+
+class ChatGPTSuggestionTest extends WebTestCase
+{
+    use InteractsWithLiveComponents;
+    private function testGenericPrompt(string $field, string $expectedPrompt): void
+    {
+        $client = self::createClient();
+        $client->loginUser($this->getUser());
+
+        $testComponent = $this->createLiveComponent(
+            name: ChatGPTSuggestion::class,
+            data: [
+                    'book' => $this->getBook(),
+                    "field" => $field,
+                    "prompt" => 'My Prompt',
+            ],
+            client: $client
+        );
+
+        self::assertStringContainsString($expectedPrompt, $testComponent->render());
+    }
+
+    public function testTagPrompt(): void
+    {
+        // Take the default prompt and remove the {book} part and everything after it
+        $bookPlaceholderPosition = strpos(TagPrompt::DEFAULT_KEYWORD_PROMPT, '{book}');
+        self::assertNotFalse($bookPlaceholderPosition);
+        $expectedPrompt = substr(TagPrompt::DEFAULT_KEYWORD_PROMPT, 0, $bookPlaceholderPosition);
+
+        $this->testGenericPrompt('tags', $expectedPrompt);
+    }
+
+    public function testSummaryPrompt(): void
+    {
+
+        // Take the default prompt and remove the {book} part and everything after it
+        $bookPlaceholderPosition = strpos(SummaryPrompt::DEFAULT_KEYWORD_PROMPT, '{book}');
+        self::assertNotFalse($bookPlaceholderPosition);
+        $expectedPrompt = substr(SummaryPrompt::DEFAULT_KEYWORD_PROMPT, 0, $bookPlaceholderPosition);
+
+        $this->testGenericPrompt('summary', $expectedPrompt);
+    }
+
+    private function getUser(?string $username = null): User
+    {
+        /** @var UserRepository $repo */
+        $repo = self::getContainer()->get(UserRepository::class);
+        $user = $repo->findOneBy(['username' => $username ?? UserFixture::USER_USERNAME]);
+        assert($user instanceof User);
+
+        return $user;
+    }
+
+    private function getBook(): Book
+    {
+        /** @var BookRepository $repo */
+        $repo = self::getContainer()->get(BookRepository::class);
+
+        $book = $repo->findOneBy(["id" => BookFixture::ID]);
+        assert($book instanceof Book);
+
+        return $book;
+    }
+}


### PR DESCRIPTION
I ran the command to tag books for the first time, and all tags were something like "How can I assist you today?".
I realized that it's because my user do not have a prompt configured. 

This put a default prompt, so the feature works "out of the box" (given you configured an OpenAI token).


Switched to draft as:

- [x] Test change with Summary
- [x] Write unit test