### PR TITLE
Simplify Xdebug setup via DockerFile

### DIFF
--- a/doc/Dockerfile
+++ b/doc/Dockerfile
@@ -1,13 +1,6 @@
-FROM ghcr.io/biblioverse/biblioteca-docker:1.0.11 as base
-
-FROM base as debug
+FROM ghcr.io/biblioverse/biblioteca-docker:latest as base
 USER root
-RUN /usr/local/bin/install-php-extensions xdebug
-
-# Somehow echo -e is not working
-RUN echo ' \n\
-[xdebug] \n\
-xdebug.idekey=PHPSTORM \n\
-xdebug.mode=off \n\
-xdebug.client_host=host.docker.internal\n ' >> /usr/local/etc/php/conf.d/biblioteca.ini
+RUN install-php-extensions xdebug
+ENV XDEBUG_MODE=debug
+ENV XDEBUG_CONFIG="client_host=host.docker.internal"
 USER www-data


### PR DESCRIPTION
For me, either we use the base image as is for production, or we setup a DockerFile to have xdebug.

- [x] Xdebug is enabled by default on the template (the user can use it or not)
- [x] Removal of the "echo" statement for something easier