### PR TITLE
Kobo sync fixes: Read progression is now handled

### DIFF
--- a/migrations/Version20240812195147.php
+++ b/migrations/Version20240812195147.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20240812195147 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add bookmarks';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('CREATE TABLE bookmark_user (id INT AUTO_INCREMENT NOT NULL, user_id INT NOT NULL, book_id INT NOT NULL, percent DOUBLE PRECISION DEFAULT NULL, source_percent DOUBLE PRECISION DEFAULT NULL, location_value VARCHAR(255) DEFAULT NULL, location_type VARCHAR(255) DEFAULT NULL, location_source VARCHAR(255) DEFAULT NULL,  updated DATETIME DEFAULT NULL, INDEX IDX_6F0BEE95A76ED395 (user_id), INDEX IDX_6F0BEE9516A2B381 (book_id), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8 COLLATE `utf8_unicode_ci` ENGINE = InnoDB');
+        $this->addSql('ALTER TABLE bookmark_user ADD CONSTRAINT FK_6F0BEE95A76ED395 FOREIGN KEY (user_id) REFERENCES `user` (id)');
+        $this->addSql('ALTER TABLE bookmark_user ADD CONSTRAINT FK_6F0BEE9516A2B381 FOREIGN KEY (book_id) REFERENCES book (id)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE bookmark_user DROP FOREIGN KEY FK_6F0BEE95A76ED395');
+        $this->addSql('ALTER TABLE bookmark_user DROP FOREIGN KEY FK_6F0BEE9516A2B381');
+        $this->addSql('DROP TABLE bookmark_user');
+    }
+}

--- a/src/Controller/Kobo/KoboStateController.php
+++ b/src/Controller/Kobo/KoboStateController.php
@@ -61,6 +61,9 @@ class KoboStateController extends AbstractController
             case ReadingStateStatusInfo::STATUS_FINISHED:
                 $this->bookProgressionService->setProgression($book, $kobo->getUser(), 1.0);
                 break;
+            case ReadingStateStatusInfo::STATUS_READY_TO_READ:
+                $this->bookProgressionService->setProgression($book, $kobo->getUser(), 0.0);
+                break;
             case ReadingStateStatusInfo::STATUS_READING:
                 $progress = $state->currentBookmark?->progressPercent;
                 $progress = $progress !== null ? $progress / 100 : null;

--- a/src/Controller/Kobo/KoboStateController.php
+++ b/src/Controller/Kobo/KoboStateController.php
@@ -64,7 +64,7 @@ class KoboStateController extends AbstractController
                 $this->bookProgressionService->setProgression($book, $kobo->getUser(), 1.0);
                 break;
             case ReadingStateStatusInfo::STATUS_READY_TO_READ:
-                $this->bookProgressionService->setProgression($book, $kobo->getUser(), 0.0);
+                $this->bookProgressionService->setProgression($book, $kobo->getUser(), null);
                 break;
             case ReadingStateStatusInfo::STATUS_READING:
                 $progress = $state->currentBookmark?->progressPercent;

--- a/src/Controller/Kobo/KoboSyncController.php
+++ b/src/Controller/Kobo/KoboSyncController.php
@@ -52,7 +52,7 @@ class KoboSyncController extends AbstractController
         $forced = $kobo->isForceSync() || $request->query->has('force');
         $count = $this->koboSyncedBookRepository->countByKoboDevice($kobo);
         if ($forced || $count === 0) {
-            if ($count > 0 || $forced) {
+            if ($forced) {
                 $this->logger->debug('Force sync for Kobo {id}', ['id' => $kobo->getId()]);
                 $this->koboSyncedBookRepository->deleteAllSyncedBooks($kobo);
                 $kobo->setForceSync(false);

--- a/src/Controller/Kobo/KoboTagController.php
+++ b/src/Controller/Kobo/KoboTagController.php
@@ -63,8 +63,7 @@ class KoboTagController extends AbstractController
         }
         $this->shelfRepository->flush();
 
-        // TODO Find the response format for this
-        return new JsonResponse([], Response::HTTP_NOT_IMPLEMENTED);
+        return new JsonResponse($shelfId, Response::HTTP_CREATED);
     }
 
     #[Route('/v1/library/tags')]

--- a/src/Entity/Book.php
+++ b/src/Entity/Book.php
@@ -89,7 +89,11 @@ class Book
     #[ORM\OneToMany(mappedBy: 'book', targetEntity: BookInteraction::class, cascade: ['remove'], orphanRemoval: true)]
     #[ORM\OrderBy(['updated' => 'ASC'])]
     private Collection $bookInteractions;
-
+    /**
+     * @var Collection<int, BookmarkUser>
+     */
+    #[ORM\OneToMany(mappedBy: 'book', targetEntity: BookmarkUser::class, orphanRemoval: true)]
+    private Collection $bookmarkUsers;
     /**
      * @var array<string>|null
      */
@@ -120,6 +124,7 @@ class Book
         $this->shelves = new ArrayCollection();
         $this->uuid = $this->generateUuid();
         $this->koboSyncedBooks = new ArrayCollection();
+        $this->bookmarkUsers = new ArrayCollection();
     }
 
     public function getId(): ?int
@@ -563,6 +568,24 @@ class Book
     public function setUuid(?string $uuid): self
     {
         $this->uuid = $uuid;
+
+        return $this;
+    }
+
+    /**
+     * @return Collection<int, BookmarkUser>
+     */
+    public function getBookmarkUsers(): Collection
+    {
+        return $this->bookmarkUsers;
+    }
+
+    /**
+     * @param Collection<int, BookmarkUser> $bookmarkUsers
+     */
+    public function setBookmarkUsers(Collection $bookmarkUsers): self
+    {
+        $this->bookmarkUsers = $bookmarkUsers;
 
         return $this;
     }

--- a/src/Entity/BookmarkUser.php
+++ b/src/Entity/BookmarkUser.php
@@ -1,0 +1,164 @@
+<?php
+
+namespace App\Entity;
+
+use App\Repository\BookmarkUserRepository;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+use Gedmo\Mapping\Annotation as Gedmo;
+
+#[ORM\Entity(repositoryClass: BookmarkUserRepository::class)]
+class BookmarkUser
+{
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column]
+    private ?int $id = null;
+
+    #[ORM\Column(nullable: true)]
+    private ?float $percent = null;
+
+    #[ORM\Column(nullable: true)]
+    private ?float $sourcePercent = null;
+
+    #[ORM\Column(length: 255, nullable: true)]
+    private ?string $locationValue = null;
+
+    #[ORM\Column(length: 255, nullable: true)]
+    private ?string $locationType = null;
+
+    #[ORM\Column(length: 255, nullable: true)]
+    private ?string $locationSource = null;
+
+    #[ORM\ManyToOne(inversedBy: 'bookmarkUsers')]
+    #[ORM\JoinColumn(nullable: false)]
+    private ?User $user;
+
+    #[ORM\ManyToOne(inversedBy: 'bookmarkUsers')]
+    #[ORM\JoinColumn(nullable: false)]
+    private ?Book $book;
+
+    #[ORM\Column(type: Types::DATETIME_MUTABLE, nullable: true)]
+    #[Gedmo\Timestampable(on: 'update')]
+    private ?\DateTimeInterface $updated;
+
+    public function __construct(?Book $book, ?User $user)
+    {
+        $this->book = $book;
+        $this->user = $user;
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getPercent(): ?float
+    {
+        return $this->percent;
+    }
+
+    public function getPercentAsInt(): ?int
+    {
+        return $this->percent === null ? null : intval($this->percent * 100);
+    }
+
+    public function setPercent(?float $percent): static
+    {
+        $this->percent = $percent;
+
+        return $this;
+    }
+
+    public function getSourcePercent(): ?float
+    {
+        return $this->sourcePercent;
+    }
+
+    public function getSourcePercentAsInt(): ?int
+    {
+        return $this->sourcePercent === null ? null : intval($this->sourcePercent * 100);
+    }
+
+    public function setSourcePercent(?float $sourcePercent): static
+    {
+        $this->sourcePercent = $sourcePercent;
+
+        return $this;
+    }
+
+    public function getLocationValue(): ?string
+    {
+        return $this->locationValue;
+    }
+
+    public function setLocationValue(?string $locationValue): static
+    {
+        $this->locationValue = $locationValue;
+
+        return $this;
+    }
+
+    public function getLocationType(): ?string
+    {
+        return $this->locationType;
+    }
+
+    public function setLocationType(?string $locationType): static
+    {
+        $this->locationType = $locationType;
+
+        return $this;
+    }
+
+    public function getLocationSource(): ?string
+    {
+        return $this->locationSource;
+    }
+
+    public function setLocationSource(?string $locationSource): static
+    {
+        $this->locationSource = $locationSource;
+
+        return $this;
+    }
+
+    public function getUser(): ?User
+    {
+        return $this->user;
+    }
+
+    public function setUser(?User $user): static
+    {
+        $this->user = $user;
+
+        return $this;
+    }
+
+    public function hasLocation(): bool
+    {
+        return $this->locationValue !== null;
+    }
+
+    public function setBook(?Book $book): self
+    {
+        $this->book = $book;
+
+        return $this;
+    }
+
+    public function getBook(): ?Book
+    {
+        return $this->book;
+    }
+
+    public function getUpdated(): ?\DateTimeInterface
+    {
+        return $this->updated;
+    }
+
+    public function setUpdated(?\DateTimeInterface $updated): void
+    {
+        $this->updated = $updated;
+    }
+}

--- a/src/Kobo/Request/ReadingStateStatusInfo.php
+++ b/src/Kobo/Request/ReadingStateStatusInfo.php
@@ -6,6 +6,7 @@ class ReadingStateStatusInfo
 {
     public const STATUS_READING = 'Reading';
     public const STATUS_FINISHED = 'Finished';
+    public const STATUS_READY_TO_READ = 'ReadyToRead';
 
     public ?\DateTimeImmutable $lastModified = null;
 

--- a/src/Kobo/Response/SyncResponse.php
+++ b/src/Kobo/Response/SyncResponse.php
@@ -127,7 +127,7 @@ class SyncResponse
             'PriorityTimestamp' => $this->syncToken->maxLastCreated($book->getCreated(), $this->syncToken->currentDate),
 
             'StatusInfo' => [
-                'LastModified' => $book->getLastInteraction($this->kobo->getUser())?->getUpdated(),
+                'LastModified' => $this->syncToken->maxLastModified($book->getLastInteraction($this->kobo->getUser())?->getUpdated(), $this->getLastBookmarkDate($book), $this->syncToken->currentDate),
                 'Status' => match ($this->isReadingFinished($book)) {
                     true => SyncResponse::READING_STATUS_FINISHED,
                     false => SyncResponse::READING_STATUS_IN_PROGRESS,
@@ -287,5 +287,10 @@ class SyncResponse
         }
 
         return array_filter($values); // Remove null values
+    }
+
+    private function getLastBookmarkDate(Book $book): ?\DateTimeInterface
+    {
+        return $this->kobo->getUser()->getBookmarkForBook($book)?->getUpdated();
     }
 }

--- a/src/Kobo/Response/SyncResponseFactory.php
+++ b/src/Kobo/Response/SyncResponseFactory.php
@@ -5,6 +5,7 @@ namespace App\Kobo\Response;
 use App\Entity\Book;
 use App\Entity\KoboDevice;
 use App\Kobo\SyncToken;
+use App\Service\BookProgressionService;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\Serializer\SerializerInterface;
 
@@ -13,13 +14,22 @@ use Symfony\Component\Serializer\SerializerInterface;
  */
 class SyncResponseFactory
 {
-    public function __construct(protected MetadataResponseService $metadataResponseService, protected SerializerInterface $serializer)
+    public function __construct(
+        protected MetadataResponseService $metadataResponseService,
+        protected BookProgressionService $bookProgressionService,
+        protected SerializerInterface $serializer)
     {
     }
 
     public function create(SyncToken $syncToken, KoboDevice $kobo): SyncResponse
     {
-        return new SyncResponse($this->metadataResponseService, $syncToken, $kobo, $this->serializer);
+        return new SyncResponse(
+            $this->metadataResponseService,
+            $this->bookProgressionService,
+            $syncToken,
+            $kobo,
+            $this->serializer
+        );
     }
 
     public function createMetadata(KoboDevice $kobo, Book $book): JsonResponse

--- a/src/Repository/BookmarkUserRepository.php
+++ b/src/Repository/BookmarkUserRepository.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Repository;
+
+use App\Entity\BookmarkUser;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @extends ServiceEntityRepository<BookmarkUser>
+ */
+class BookmarkUserRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, BookmarkUser::class);
+    }
+
+    //    /**
+    //     * @return BookmarkUser[] Returns an array of BookmarkUser objects
+    //     */
+    //    public function findByExampleField($value): array
+    //    {
+    //        return $this->createQueryBuilder('b')
+    //            ->andWhere('b.exampleField = :val')
+    //            ->setParameter('val', $value)
+    //            ->orderBy('b.id', 'ASC')
+    //            ->setMaxResults(10)
+    //            ->getQuery()
+    //            ->getResult()
+    //        ;
+    //    }
+
+    //    public function findOneBySomeField($value): ?BookmarkUser
+    //    {
+    //        return $this->createQueryBuilder('b')
+    //            ->andWhere('b.exampleField = :val')
+    //            ->setParameter('val', $value)
+    //            ->getQuery()
+    //            ->getOneOrNullResult()
+    //        ;
+    //    }
+}

--- a/src/Service/BookProgressionService.php
+++ b/src/Service/BookProgressionService.php
@@ -40,6 +40,12 @@ class BookProgressionService
     public function setProgression(Book $book, User $user, ?float $progress): self
     {
         if ($progress === null) {
+            $interaction = $book->getLastInteraction($user);
+            if ($interaction instanceof BookInteraction) {
+                $interaction->setReadPages(null);
+                $interaction->setFinished(false);
+            }
+
             return $this;
         }
 

--- a/tests/Controller/Kobo/KoboStateControllerTest.php
+++ b/tests/Controller/Kobo/KoboStateControllerTest.php
@@ -80,7 +80,11 @@ class KoboStateControllerTest extends AbstractKoboControllerTest
         $state->currentBookmark->lastModified = new \DateTime();
         $state->entitlementId = $bookUuid;
         $state->statusInfo = new ReadingStateStatusInfo();
-        $state->statusInfo->status = $percent === 100 ? ReadingStateStatusInfo::STATUS_FINISHED : ReadingStateStatusInfo::STATUS_READING;
+        $state->statusInfo->status = match($percent) {
+            0 => ReadingStateStatusInfo::STATUS_READY_TO_READ,
+            100 => ReadingStateStatusInfo::STATUS_FINISHED,
+            default => ReadingStateStatusInfo::STATUS_READING,
+        };
         $state->statusInfo->lastModified = $state->lastModified;
         $state->statistics = new ReadingStateStatistics();
         $state->statistics->remainingTimeMinutes = (int) (100 * ($percent/100));

--- a/tests/Service/BookProgressionServiceTest.php
+++ b/tests/Service/BookProgressionServiceTest.php
@@ -5,6 +5,7 @@ namespace App\Tests\Service;
 use App\DataFixtures\BookFixture;
 use App\DataFixtures\UserFixture;
 use App\Entity\Book;
+use App\Entity\BookInteraction;
 use App\Entity\User;
 use App\Repository\BookRepository;
 use App\Repository\UserRepository;
@@ -78,6 +79,24 @@ class BookProgressionServiceTest extends KernelTestCase
 
         self::assertFalse($lastInteraction->isFinished(), 'Book should not be finished');
         self::assertSame(15, $lastInteraction->getReadPages(), 'Book should have half page read');
+    }
+
+    public function testMarkAsUnread(): void{
+        $service = $this->getProgressionService();
+        $book = $this->getBook();
+        // Make sure we have 0 interactions
+        $interaction = new BookInteraction();
+        $interaction->setBook($book);
+        $interaction->setUser($this->getUser());
+        $interaction->setReadPages(12);
+
+        $book->getBookInteractions()->add($interaction);
+        $service->setProgression($book, $this->getUser(), null);
+        $lastInteraction = $book->getLastInteraction($this->getUser());
+        self::assertNotNull($lastInteraction, 'Interaction should be created');
+
+        self::assertFalse($lastInteraction->isFinished(), 'Book should not be finished');
+        self::assertNull($lastInteraction->getReadPages(), 'Book should have null page read');
     }
 
 


### PR DESCRIPTION
- Add "Ready to read" status so books are not all considered as "reading 1%"
- Save Reading progression and bookmarks from Kobo
- Sync book that have been modified since last sync only
- Removing a book from Kobo unlink it from the shelf correctly
- get state is now implemented with an empty response to speed up sync
- push analytics proxy the request asynchronously to speed up sync