### PR TITLE
Reading bookmark fix

### DIFF
--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -50,6 +50,7 @@ security:
     # Easy way to control access for large sections of your site
     # Note: Only the *first* access control that matches will be used
     access_control:
+        - { path: ^/api/v3/content/checkforchanges, roles: PUBLIC_ACCESS }
         - { path: ^/login, roles: PUBLIC_ACCESS }
         - { path: ^/logout, roles: ROLE_USER }
         - { path: ^/, roles: ROLE_USER }

--- a/migrations/Version20241121135658.php
+++ b/migrations/Version20241121135658.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20241121135658 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add device_id to kobo device';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE kobo_device ADD device_id VARCHAR(255) DEFAULT NULL');
+        $this->addSql('CREATE INDEX kobo_device_id ON kobo_device (device_id);');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP INDEX kobo_device_id ON kobo_device;');
+        $this->addSql('ALTER TABLE kobo_device DROP device_id;');
+    }
+}

--- a/migrations/Version20241121142239.php
+++ b/migrations/Version20241121142239.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20241121142239 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add model to kobo device';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE kobo_device ADD model VARCHAR(255) DEFAULT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE kobo_device DROP model');
+    }
+}

--- a/src/Controller/Kobo/KoboAnalyticsController.php
+++ b/src/Controller/Kobo/KoboAnalyticsController.php
@@ -57,8 +57,8 @@ class KoboAnalyticsController extends AbstractController
         // Save the device_id and model
         if ($request->headers->has(KoboDevice::KOBO_DEVICE_ID_HEADER)) {
             $kobo->setDeviceId($request->headers->get(KoboDevice::KOBO_DEVICE_ID_HEADER));
-            if ($request->headers->has(KoboDevice::KOBO_DEVICE_MODEL)) {
-                $kobo->setModel($request->headers->get(KoboDevice::KOBO_DEVICE_MODEL));
+            if ($request->headers->has(KoboDevice::KOBO_DEVICE_MODEL_HEADER)) {
+                $kobo->setModel($request->headers->get(KoboDevice::KOBO_DEVICE_MODEL_HEADER));
             }
             $this->koboDeviceRepository->save($kobo);
         }

--- a/src/Controller/Kobo/KoboAnalyticsController.php
+++ b/src/Controller/Kobo/KoboAnalyticsController.php
@@ -2,8 +2,10 @@
 
 namespace App\Controller\Kobo;
 
+use App\Entity\KoboDevice;
 use App\Kobo\Proxy\KoboProxyConfiguration;
 use App\Kobo\Proxy\KoboStoreProxy;
+use App\Repository\KoboDeviceRepository;
 use GuzzleHttp\Exception\GuzzleException;
 use Psr\Log\LoggerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
@@ -16,8 +18,12 @@ use Symfony\Component\Routing\Attribute\Route;
 #[Route('/kobo/{accessKey}', name: 'kobo')]
 class KoboAnalyticsController extends AbstractController
 {
-    public function __construct(protected KoboProxyConfiguration $koboProxyConfiguration, protected KoboStoreProxy $koboStoreProxy, protected LoggerInterface $logger)
-    {
+    public function __construct(
+        protected KoboProxyConfiguration $koboProxyConfiguration,
+        protected KoboStoreProxy $koboStoreProxy,
+        protected KoboDeviceRepository $koboDeviceRepository,
+        protected LoggerInterface $logger,
+    ) {
     }
 
     /**
@@ -46,8 +52,17 @@ class KoboAnalyticsController extends AbstractController
      * @throws GuzzleException
      */
     #[Route('/v1/analytics/event', methods: ['POST'])]
-    public function analyticsEvent(Request $request): Response
+    public function analyticsEvent(Request $request, KoboDevice $kobo): Response
     {
+        // Save the device_id and model
+        if ($request->headers->has(KoboDevice::KOBO_DEVICE_ID_HEADER)) {
+            $kobo->setDeviceId($request->headers->get(KoboDevice::KOBO_DEVICE_ID_HEADER));
+            if ($request->headers->has(KoboDevice::KOBO_DEVICE_MODEL)) {
+                $kobo->setModel($request->headers->get(KoboDevice::KOBO_DEVICE_MODEL));
+            }
+            $this->koboDeviceRepository->save($kobo);
+        }
+
         $content = $request->getContent();
         $json = trim($content) === '' ? [] : (array) json_decode($content, true, 512, JSON_THROW_ON_ERROR);
         $this->logger->debug('Analytics event received', ['body' => $json]);

--- a/src/Controller/Kobo/KoboInitializationController.php
+++ b/src/Controller/Kobo/KoboInitializationController.php
@@ -50,10 +50,11 @@ class KoboInitializationController extends AbstractController
 
         // Image host: https://<domain>
         $jsonData['Resources']['image_host'] = rtrim($this->generateUrl('app_dashboard', [], UrlGenerator::ABSOLUTE_URL), '/');
-
-        // TODO: Use router instead of hard-coding path.
         $jsonData['Resources']['image_url_template'] = $base.'/image/{ImageId}/{width}/{height}/{Quality}/isGreyscale/image.jpg';
         $jsonData['Resources']['image_url_quality_template'] = $base.'/{ImageId}/{width}/{height}/false/image.jpg';
+
+        // Reading services
+        $jsonData['Resources']['reading_services_host'] = rtrim($this->generateUrl('app_dashboard', [], UrlGenerator::ABSOLUTE_URL), '/');
 
         $response = new JsonResponse($jsonData);
         $response->headers->set('kobo-api-token', 'e30=');

--- a/src/Controller/Kobo/ReadServiceCheckForChangesController.php
+++ b/src/Controller/Kobo/ReadServiceCheckForChangesController.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Controller\Kobo;
+
+use App\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+
+class ReadServiceCheckForChangesController extends AbstractController
+{
+    #[Route('/api/v3/content/checkforchanges', name: 'check_for_changes', methods: ['POST'])]
+    public function checkForChanges(): Response
+    {
+        // If you set "reading_services_host" on your Kobo's config you should point here.
+        // This endpoint tells the kobo that the book reading status has not changed.
+        // If you don't implement it, opening a book on the kobo will reset your progress
+        // to the beginning of the current chapter.
+        return new JsonResponse([]);
+    }
+}

--- a/src/Entity/KoboDevice.php
+++ b/src/Entity/KoboDevice.php
@@ -18,7 +18,7 @@ class KoboDevice
 {
     use RandomGeneratorTrait;
     public const KOBO_DEVICE_ID_HEADER = 'X-Kobo-Deviceid';
-    public const KOBO_DEVICE_MODEL = 'X-Kobo-Devicemodel';
+    public const KOBO_DEVICE_MODEL_HEADER = 'X-Kobo-Devicemodel';
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column]

--- a/src/Entity/KoboDevice.php
+++ b/src/Entity/KoboDevice.php
@@ -11,10 +11,14 @@ use Symfony\Component\Validator\Constraints as Assert;
 
 #[ORM\Entity(repositoryClass: KoboDeviceRepository::class)]
 #[ORM\UniqueConstraint(name: 'kobo_access_key', columns: ['access_key'])]
+#[ORM\Index(columns: ['device_id'], name: 'kobo_device_id')]
+#[ORM\Index(columns: ['access_key'], name: 'kobo_access_key')]
 #[UniqueEntity(fields: ['accessKey'])]
 class KoboDevice
 {
     use RandomGeneratorTrait;
+    public const KOBO_DEVICE_ID_HEADER = 'X-Kobo-Deviceid';
+    public const KOBO_DEVICE_MODEL = 'X-Kobo-Devicemodel';
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column]
@@ -34,6 +38,11 @@ class KoboDevice
     #[Assert\Regex(pattern: '/^[a-f0-9]+$/', message: 'Need to be Hexadecimal')]
     private ?string $accessKey = null;
 
+    #[ORM\Column(length: 255, nullable: true)]
+    private ?string $deviceId = null;
+
+    #[ORM\Column(length: 255, nullable: true)]
+    private ?string $model = null;
     /**
      * @var Collection<int, Shelf>
      */
@@ -161,5 +170,29 @@ class KoboDevice
     public function removeShelf(Shelf $shelf): void
     {
         $this->shelves->removeElement($shelf);
+    }
+
+    public function getDeviceId(): ?string
+    {
+        return $this->deviceId;
+    }
+
+    public function setDeviceId(?string $deviceId): self
+    {
+        $this->deviceId = $deviceId;
+
+        return $this;
+    }
+
+    public function getModel(): ?string
+    {
+        return $this->model;
+    }
+
+    public function setModel(?string $model): self
+    {
+        $this->model = $model;
+
+        return $this;
     }
 }

--- a/src/Form/KoboType.php
+++ b/src/Form/KoboType.php
@@ -23,6 +23,16 @@ class KoboType extends AbstractType
         $builder
             ->add('name')
             ->add('accessKey')
+            ->add('deviceId', null, [
+                'label' => 'Device ID',
+                'disabled' => true,
+                'required' => false,
+            ])
+            ->add('model', null, [
+                'label' => 'Model',
+                'disabled' => true,
+                'required' => false,
+            ])
             ->add('forceSync', null, [
                 'label' => 'Force Sync',
                 'required' => false,

--- a/src/Kobo/Response/ReadingStateResponse.php
+++ b/src/Kobo/Response/ReadingStateResponse.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace App\Kobo\Response;
+
+use App\Entity\Book;
+use App\Entity\BookmarkUser;
+use App\Entity\KoboDevice;
+use App\Kobo\SyncToken;
+use App\Service\BookProgressionService;
+use Symfony\Component\Serializer\Normalizer\DateTimeNormalizer;
+use Symfony\Component\Serializer\SerializerInterface;
+
+class ReadingStateResponse
+{
+    public function __construct(
+        protected BookProgressionService $bookProgressionService,
+        protected SerializerInterface $serializer,
+        protected SyncToken $syncToken,
+        protected KoboDevice $kobo,
+        protected Book $book,
+    ) {
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function createReadingState(): array
+    {
+        $book = $this->book;
+        $uuid = $book->getUuid();
+
+        $lastModified = $this->syncToken->maxLastModified($book->getUpdated(), $this->syncToken->currentDate, $book->getLastInteraction($this->kobo->getUser())?->getUpdated());
+
+        return [
+            'EntitlementId' => $uuid,
+            'Created' => $this->syncToken->maxLastCreated($book->getCreated(), $this->syncToken->currentDate, $book->getLastInteraction($this->kobo->getUser())?->getCreated()),
+            'LastModified' => $lastModified,
+            'PriorityTimestamp' => $lastModified,
+            'StatusInfo' => [
+                'LastModified' => $lastModified,
+                'Status' => match ($this->isReadingFinished($book)) {
+                    true => SyncResponse::READING_STATUS_FINISHED,
+                    false => SyncResponse::READING_STATUS_IN_PROGRESS,
+                    null => SyncResponse::READING_STATUS_UNREAD,
+                },
+                'TimesStartedReading' => 0,
+            ],
+
+            // "Statistics"=> get_statistics_response(kobo_reading_state.statistics),
+            'CurrentBookmark' => $this->createBookmark($this->kobo->getUser()->getBookmarkForBook($book)),
+        ];
+    }
+
+    /**
+     * @return bool|null Null if we do not now the reading state
+     */
+    private function isReadingFinished(Book $book): ?bool
+    {
+        $progression = $this->bookProgressionService->getProgression($book, $this->kobo->getUser());
+        if ($progression === null) {
+            return null;
+        }
+
+        return $progression >= 1.0;
+    }
+
+    private function createBookmark(?BookmarkUser $bookMark): array
+    {
+        if (!$bookMark instanceof BookmarkUser) {
+            return [];
+        }
+
+        $values = [
+            'Location' => [
+                'Type' => $bookMark->getLocationType(),
+                'Value' => $bookMark->getLocationValue(),
+                'Source' => $bookMark->getLocationSource(),
+            ],
+            'ProgressPercent' => $bookMark->getPercentAsInt(),
+            'ContentSourceProgressPercent' => $bookMark->getSourcePercentAsInt(),
+        ];
+
+        if (false === $bookMark->hasLocation()) {
+            unset($values['Location']);
+        }
+
+        return array_filter($values); // Remove null values
+    }
+
+    public function __toString(): string
+    {
+        return $this->serializer->serialize($this->createReadingState(), 'json', [DateTimeNormalizer::FORMAT_KEY => SyncResponse::DATE_FORMAT]);
+    }
+}

--- a/src/Kobo/Response/ReadingStateResponseFactory.php
+++ b/src/Kobo/Response/ReadingStateResponseFactory.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Kobo\Response;
+
+use App\Entity\Book;
+use App\Entity\KoboDevice;
+use App\Kobo\SyncToken;
+use App\Service\BookProgressionService;
+use Symfony\Component\Serializer\SerializerInterface;
+
+/**
+ * Inspired by https://github.com/janeczku/calibre-web/blob/master/cps/kobo.py
+ */
+class ReadingStateResponseFactory
+{
+    public function __construct(
+        protected MetadataResponseService $metadataResponseService,
+        protected BookProgressionService $bookProgressionService,
+        protected SerializerInterface $serializer)
+    {
+    }
+
+    public function create(SyncToken $syncToken, KoboDevice $kobo, Book $book): ReadingStateResponse
+    {
+        return new ReadingStateResponse(
+            $this->bookProgressionService,
+            $this->serializer,
+            $syncToken,
+            $kobo,
+            $book
+        );
+    }
+}

--- a/src/Kobo/Response/StateResponse.php
+++ b/src/Kobo/Response/StateResponse.php
@@ -26,6 +26,6 @@ class StateResponse extends JsonResponse
                     ],
                 ],
             ],
-        ], Response::HTTP_NO_CONTENT);
+        ], Response::HTTP_OK);
     }
 }

--- a/src/Kobo/Response/SyncResponseFactory.php
+++ b/src/Kobo/Response/SyncResponseFactory.php
@@ -17,8 +17,9 @@ class SyncResponseFactory
     public function __construct(
         protected MetadataResponseService $metadataResponseService,
         protected BookProgressionService $bookProgressionService,
-        protected SerializerInterface $serializer)
-    {
+        protected SerializerInterface $serializer,
+        protected ReadingStateResponseFactory $readingStateResponseFactory,
+    ) {
     }
 
     public function create(SyncToken $syncToken, KoboDevice $kobo): SyncResponse
@@ -28,7 +29,8 @@ class SyncResponseFactory
             $this->bookProgressionService,
             $syncToken,
             $kobo,
-            $this->serializer
+            $this->serializer,
+            $this->readingStateResponseFactory,
         );
     }
 

--- a/src/Kobo/Response/SyncResponseHelper.php
+++ b/src/Kobo/Response/SyncResponseHelper.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Kobo\Response;
+
+use App\Entity\Book;
+use App\Entity\BookInteraction;
+use App\Entity\KoboDevice;
+use App\Kobo\SyncToken;
+
+// Inspired by https://github.com/janeczku/calibre-web/blob/master/cps/kobo.py
+
+/**
+ * @phpstan-type BookEntitlement array<string, mixed>
+ * @phpstan-type BookMetadata array<string, mixed>
+ * @phpstan-type BookReadingState array<string, mixed>
+ * @phpstan-type BookTag array<string, mixed>
+ */
+class SyncResponseHelper
+{
+    public function isChangedEntitlement(Book $book, KoboDevice $kobo, SyncToken $syncToken): bool
+    {
+        if ($this->isNewEntitlement($book, $syncToken)) {
+            return false;
+        }
+
+        if ($this->isChangedReadingState($book, $kobo, $syncToken)) {
+            return false;
+        }
+
+        return ($book->getUpdated() instanceof \DateTimeInterface
+            && $book->getUpdated() >= $syncToken->lastModified)
+            || $book->getCreated() >= $syncToken->lastCreated;
+    }
+
+    public function isNewEntitlement(Book $book, SyncToken $syncToken): bool
+    {
+        return $book->getKoboSyncedBook()->isEmpty() || $book->getCreated() < $syncToken->lastCreated;
+    }
+
+    public function isChangedReadingState(Book $book, KoboDevice $kobo, SyncToken $syncToken): bool
+    {
+        if ($this->isNewEntitlement($book, $syncToken)) {
+            return false;
+        }
+        $lastInteraction = $book->getLastInteraction($kobo->getUser());
+
+        return ($lastInteraction instanceof BookInteraction) && $lastInteraction->getUpdated() >= $syncToken->readingStateLastModified;
+    }
+}

--- a/src/Kobo/SyncToken.php
+++ b/src/Kobo/SyncToken.php
@@ -46,7 +46,7 @@ class SyncToken
 
     public function maxLastModified(?\DateTimeInterface ...$value): ?\DateTimeInterface
     {
-        return $this->max(
+        return self::max(
             $this->lastModified,
             ...$value
         );
@@ -54,13 +54,13 @@ class SyncToken
 
     public function maxLastCreated(?\DateTimeInterface ...$value): ?\DateTimeInterface
     {
-        return $this->max(
+        return self::max(
             $this->lastCreated,
             ...$value
         );
     }
 
-    protected function max(?\DateTimeInterface ...$dates): ?\DateTimeInterface
+    protected static function max(?\DateTimeInterface ...$dates): ?\DateTimeInterface
     {
         $max = null;
         foreach ($dates as $date) {

--- a/src/Repository/KoboDeviceRepository.php
+++ b/src/Repository/KoboDeviceRepository.php
@@ -50,4 +50,10 @@ class KoboDeviceRepository extends ServiceEntityRepository
 
         return $result;
     }
+
+    public function save(KoboDevice $kobo): void
+    {
+        $this->_em->persist($kobo);
+        $this->_em->flush();
+    }
 }

--- a/templates/kobodevice_user/index.html.twig
+++ b/templates/kobodevice_user/index.html.twig
@@ -14,7 +14,11 @@
         <tbody>
         {% for kobo in kobos %}
             <tr>
-                <td>{{ kobo.name }}</td>
+                <td>{{ kobo.name }}
+                {% if kobo.model is not empty %}
+                   <br /><small class="text-muted">{{ kobo.model }}</small>
+                {% endif %}
+                </td>
                 <td>{{ kobo.accessKey }}</td>
                 <td>
                     {% if is_granted('EDIT', kobo) %}

--- a/templates/kobodevice_user/instructions.html.twig
+++ b/templates/kobodevice_user/instructions.html.twig
@@ -8,6 +8,7 @@
             <li>Edit the file with a text editor (vs-code, vim, etc).</li>
             <li>
                 Alter the line <code>api_endpoint</code> under the section <code>[OneStoreServices]</code> (or create it if it doesn't exist). <br>
+                Make sure to replace the <code>reading_services_host</code> if it exists, to avoid loosing your reading progression. <br>
                 You can also edit the <code>image_host</code> and <code>image_url_quality_template</code> entries.
                 <pre>
                     {% apply spaceless -%}
@@ -23,6 +24,7 @@
                         {{- "\n" }}image_host={{ app.request.getUriForPath("") -}}
                         {{- "\n" }}image_url_quality_template={{ url('koboapi_endpoint', {'accessKey': token}) ~ '/image/{ImageId}/{width}/{height}/{Quality}/isGreyscale/image.jpg' -}}
                     {% endif %}
+                        {{- "\n" }}reading_services_host={{ app.request.getUriForPath("") -}}
                         {{- "\n"}}...
                     </code>
                     {%- endapply %}

--- a/tests/Controller/Kobo/KoboAnalyticsControllerTest.php
+++ b/tests/Controller/Kobo/KoboAnalyticsControllerTest.php
@@ -448,7 +448,7 @@ class KoboAnalyticsControllerTest extends AbstractKoboControllerTest
         $client?->setServerParameter('HTTP_CONNECTION', 'keep-alive');
         $server = [
             'HTTP_'.KoboDevice::KOBO_DEVICE_ID_HEADER => self::DEVICE_ID,
-            'HTTP_'.KoboDevice::KOBO_DEVICE_MODEL => self::MODEL,
+            'HTTP_'.KoboDevice::KOBO_DEVICE_MODEL_HEADER => self::MODEL,
         ];
         $client?->request('POST', '/kobo/'.$this->accessKey.'/v1/analytics/event', [
             'json' => $body,

--- a/tests/Controller/Kobo/KoboAnalyticsControllerTest.php
+++ b/tests/Controller/Kobo/KoboAnalyticsControllerTest.php
@@ -3,9 +3,13 @@
 namespace App\Tests\Controller\Kobo;
 
 
+use App\Entity\KoboDevice;
+
 class KoboAnalyticsControllerTest extends AbstractKoboControllerTest
 {
     const SERIAL_NUMBER = 'N9413679432456';
+    const DEVICE_ID = '2a92bba197b1e0574a3f7d29cb2b05b399ab0d197e6b1aa230bfb75a920b14e7c';
+    const MODEL = 'Kobo Libra H2O';
     const APP_VERSION = '4.38.21908';
 
     public function testPostEvent(): void
@@ -442,9 +446,18 @@ class KoboAnalyticsControllerTest extends AbstractKoboControllerTest
         ];
         $client = static::getClient();
         $client?->setServerParameter('HTTP_CONNECTION', 'keep-alive');
+        $server = [
+            'HTTP_'.KoboDevice::KOBO_DEVICE_ID_HEADER => self::DEVICE_ID,
+            'HTTP_'.KoboDevice::KOBO_DEVICE_MODEL => self::MODEL,
+        ];
         $client?->request('POST', '/kobo/'.$this->accessKey.'/v1/analytics/event', [
             'json' => $body,
-        ]);
+        ], [], $server);
+
+        // Make sure we define Kobo's device_id and model
+        $kobo =  $this->getKoboDevice(true);
+        self::assertSame(self::DEVICE_ID,$kobo->getDeviceId());
+        self::assertSame(self::MODEL,$kobo->getModel());
 
         self::assertResponseIsSuccessful();
         self::assertResponseHeaderSame('Connection', 'keep-alive');

--- a/tests/Controller/Kobo/ReadServiceCheckForChangesControllerTest.php
+++ b/tests/Controller/Kobo/ReadServiceCheckForChangesControllerTest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Tests\Controller\Kobo;
+
+use Symfony\Component\HttpFoundation\Response;
+
+class ReadServiceCheckForChangesControllerTest extends AbstractKoboControllerTest
+{
+    public function testCheckForChangesPost() : void
+    {
+        $client = static::getClient();
+
+        $client?->request('POST', '/api/v3/content/checkforchanges');
+        self::assertResponseIsSuccessful();
+
+        /** @var Response|null $response */
+        $response = $client?->getResponse();
+
+        $responseContent = $response?->getContent();
+        self::assertSame('[]', $responseContent);
+    }
+}


### PR DESCRIPTION
When you open a book on your kobo, it' seems the reading progression is reseted at the beginning of the chapter.

It seems that it's due to a Firmware update, when you open the book, the endpoint `/api/v3/content/checkforchanges` is fetched from <https://readingservices.kobo.com> and as the book is unknown, the progression is not working.

To remediate the issue, I mocked the endpoint (it just returns a 200 with an empty json array).
You need to reconfigure the `reading_services_host` setting on the Kobo's configuration and restart it.

This seems to fix the issue.

Other changes:
- I also implemented the `GET /v1/library/{uuid}/state` endpoint while investigating
- I refactored a bit the sync response and added the `ChangedReadingState` key while investigating
- I am now saving the Kobo's "device-id" in the database, so that `checkforchange` endpoint could be enhanced later on. 
- I am also saving the Kobo's "model" into the database, just to display it.

Note: It seems not possible to use the "accessToken" for the URL (ex:`/kobo/{accessToken}/api/v3/content/checkforchanges`) as the parameter allows us only to alter the domain name.