### PR TITLE
feat(docker): Xdebug support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,9 @@
-FROM ghcr.io/biblioverse/biblioteca-docker:latest
+FROM ghcr.io/biblioverse/biblioteca-docker:latest AS base
+WORKDIR /var/www/html
 
+FROM base AS prod
 USER root
 COPY . /var/www/html
-
-
-
-WORKDIR /var/www/html
 
 RUN composer install
 RUN npm install
@@ -13,4 +11,15 @@ RUN npm run build
 
 RUN chown -R www-data:www-data /var/www/html
 
+USER www-data
+
+FROM base AS dev
+USER root
+RUN /usr/local/bin/install-php-extensions xdebug
+
+RUN echo ' \n\
+[xdebug] \n\
+xdebug.idekey=PHPSTORM \n\
+xdebug.mode=off \n\
+xdebug.client_host=host.docker.internal\n ' >> /usr/local/etc/php/conf.d/biblioteca.ini
 USER www-data

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,8 @@
 services:
   biblioteca:
     image: ghcr.io/biblioverse/biblioteca-docker:latest
+    build:
+      target: prod
     command: ["/bin/sh", "-c" , "crontab /var/www/html/config/crontab.txt && apache2-foreground" ]
     ports:
       - "48480:8080" # Web


### PR DESCRIPTION
Put back xdebug.

I created multiple stages
- prod: The container with everything (default)
- dev: The container without the code, with Xdebug installed.

To use the dev mode, you need to create an override.yaml file like below and run the install commands manually (composer install ; npm install ; npm build).
```
services:
  biblioteca:
    build:
        target: dev
    environment:
      - XDEBUG_MODE=debug
      - PHP_IDE_CONFIG=serverName=...
```