### PR TITLE
Properly show errors when scanning books

### DIFF
--- a/src/Command/BooksScanCommand.php
+++ b/src/Command/BooksScanCommand.php
@@ -47,7 +47,7 @@ class BooksScanCommand extends Command
             }
             $io->writeln('Consuming '.$path);
             $info = new \SplFileInfo($path);
-            $book = $this->bookManager->consumeBook($info);
+            $book = $this->bookManager->consumeBook($info, $io);
             $this->entityManager->persist($book);
             $this->entityManager->flush();
             $this->fileSystemManager->renameFiles($book);

--- a/src/Command/BooksScanCommand.php
+++ b/src/Command/BooksScanCommand.php
@@ -47,7 +47,7 @@ class BooksScanCommand extends Command
             }
             $io->writeln('Consuming '.$path);
             $info = new \SplFileInfo($path);
-            $book = $this->bookManager->consumeBook($info, $io);
+            $book = $this->bookManager->consumeBook($info);
             $this->entityManager->persist($book);
             $this->entityManager->flush();
             $this->fileSystemManager->renameFiles($book);

--- a/src/Exception/BookExtractionException.php
+++ b/src/Exception/BookExtractionException.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Exception;
+
+class BookExtractionException extends \RuntimeException
+{
+    public function __construct(string $message, string $bookPath)
+    {
+        parent::__construct(sprintf("Failed extraction of '%s' with the error '%s'", $message, $bookPath));
+    }
+}

--- a/src/Exception/BookExtractionException.php
+++ b/src/Exception/BookExtractionException.php
@@ -4,8 +4,8 @@ namespace App\Exception;
 
 class BookExtractionException extends \RuntimeException
 {
-    public function __construct(string $message, string $bookPath)
+    public function __construct(string $message, string $bookPath, ?\Throwable $previous = null)
     {
-        parent::__construct(sprintf("Failed extraction of '%s' with the error '%s'", $message, $bookPath));
+        parent::__construct(sprintf("Failed extraction of '%s' with the error '%s'", $message, $bookPath), 0, $previous);
     }
 }

--- a/src/Service/BookManager.php
+++ b/src/Service/BookManager.php
@@ -159,6 +159,9 @@ class BookManager
                 } catch (BookExtractionException $e) {
                     $book = $this->createBookWithoutMetadata($file);
                     $io->error($e->getMessage());
+                    if ($e->getPrevious() instanceof \Exception) {
+                        $io->error('Caused by '.$e->getPrevious()->getMessage());
+                    }
                 }
 
                 $this->entityManager->persist($book);
@@ -166,9 +169,6 @@ class BookManager
             } catch (\Exception $e) {
                 $io->error('died during process of '.$file->getRealPath());
                 $io->error($e->getMessage());
-                if ($e->getPrevious() instanceof \Exception) {
-                    $io->error('Caused by '.$e->getPrevious()->getMessage());
-                }
                 throw $e;
             }
             $book = null;

--- a/src/Service/BookManager.php
+++ b/src/Service/BookManager.php
@@ -92,16 +92,15 @@ class BookManager
     {
         try {
             if (!Ebook::isValid($file->getRealPath())) {
-                throw new \RuntimeException('Invalid eBook: "' . $file->getRealPath() . '"');
+                throw new \RuntimeException('Invalid eBook: "'.$file->getRealPath().'"');
             }
 
             $ebook = Ebook::read($file->getRealPath());
             if (!$ebook instanceof Ebook) {
-                throw new \RuntimeException('Could not read eBook: "' . $file->getRealPath() . '"');
+                throw new \RuntimeException('Could not read eBook: "'.$file->getRealPath().'"');
             }
         } catch (\Throwable $e) {
-
-            $io->error('Could not read eBook' . $file->getRealPath() . "\n" . $e->getMessage() . "\n" . $e->getTraceAsString());
+            $io->error('Could not read eBook'.$file->getRealPath()."\n".$e->getMessage()."\n".$e->getTraceAsString());
 
             $ebook = null;
 

--- a/src/Service/BookManager.php
+++ b/src/Service/BookManager.php
@@ -116,7 +116,7 @@ class BookManager
             if (!$ebook instanceof Ebook) {
                 throw new BookExtractionException('Could not read eBook', $file->getRealPath());
             }
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             throw new BookExtractionException('Ebook Library threw an exception', $file->getRealPath(), $e);
         }
 

--- a/src/Service/BookManager.php
+++ b/src/Service/BookManager.php
@@ -3,6 +3,7 @@
 namespace App\Service;
 
 use App\Entity\Book;
+use App\Exception\BookExtractionException;
 use App\Repository\BookRepository;
 use Doctrine\ORM\EntityManagerInterface;
 use Kiwilan\Ebook\Ebook;
@@ -27,11 +28,11 @@ class BookManager
     /**
      * @throws \Exception
      */
-    public function createBook(\SplFileInfo $file, SymfonyStyle $io): Book
+    public function createBook(\SplFileInfo $file): Book
     {
         $book = new Book();
 
-        $extractedMetadata = $this->extractEbookMetadata($file, $io);
+        $extractedMetadata = $this->extractEbookMetadata($file);
         if ('' === $extractedMetadata['title'] || '.pdf' === $extractedMetadata['title']) {
             $extractedMetadata['title'] = $file->getBasename();
         }
@@ -83,40 +84,36 @@ class BookManager
         return $book;
     }
 
+    public function createBookWithoutMetadata(\SplFileInfo $file): Book
+    {
+        $book = new Book();
+
+        $book->setTitle($file->getBasename());
+        $book->setChecksum($this->fileSystemManager->getFileChecksum($file));
+        $book->addAuthor('unknown');
+
+        $book->setExtension($file->getExtension());
+
+        $book->setBookPath('');
+        $book->setBookFilename('');
+
+        return $this->updateBookLocation($book, $file);
+    }
+
     /**
      * @return MetadataType
      *
      * @throws \Exception
      */
-    public function extractEbookMetadata(\SplFileInfo $file, SymfonyStyle $io): array
+    public function extractEbookMetadata(\SplFileInfo $file): array
     {
-        try {
-            if (!Ebook::isValid($file->getRealPath())) {
-                throw new \RuntimeException('Invalid eBook: "'.$file->getRealPath().'"');
-            }
+        if (!Ebook::isValid($file->getRealPath())) {
+            throw new BookExtractionException('Invalid eBook', $file->getRealPath());
+        }
 
-            $ebook = Ebook::read($file->getRealPath());
-            if (!$ebook instanceof Ebook) {
-                throw new \RuntimeException('Could not read eBook: "'.$file->getRealPath().'"');
-            }
-        } catch (\Throwable $e) {
-            $io->error('Could not read eBook'.$file->getRealPath()."\n".$e->getMessage()."\n".$e->getTraceAsString());
-
-            $ebook = null;
-
-            return [
-                'title' => $file->getFilename(),
-                'authors' => [new BookAuthor('unknown')], // BookAuthor[] (`name`: string, `role`: string)
-                'main_author' => new BookAuthor('unknown'), // ?BookAuthor => First BookAuthor (`name`: string, `role`: string)
-                'description' => null, // ?string
-                'publisher' => null, // ?string
-                'publish_date' => null, // ?DateTime
-                'language' => null, // ?string
-                'tags' => [], // string[] => `subject` in EPUB, `keywords` in PDF, `genres` in CBA
-                'serie' => null, // ?string => `calibre:series` in EPUB, `series` in CBA
-                'serie_index' => null, // ?int => `calibre:series_index` in EPUB, `number` in CBA
-                'cover' => null, //  ?EbookCover => cover of book
-            ];
+        $ebook = Ebook::read($file->getRealPath());
+        if (!$ebook instanceof Ebook) {
+            throw new BookExtractionException('Could not read eBook', $file->getRealPath());
         }
 
         return [
@@ -151,7 +148,14 @@ class BookManager
         foreach ($files as $file) {
             $progressBar->advance();
             try {
-                $book = $this->consumeBook($file, $io);
+                $book = null;
+                try {
+                    $book = $this->consumeBook($file);
+                } catch (BookExtractionException $e) {
+                    $book = $this->createBookWithoutMetadata($file);
+                    $io->error($e->getMessage());
+                }
+
                 $progressBar->setMessage($file->getFilename());
 
                 $this->entityManager->persist($book);
@@ -167,7 +171,7 @@ class BookManager
         $progressBar->finish();
     }
 
-    public function consumeBook(\SplFileInfo $file, SymfonyStyle $io): Book
+    public function consumeBook(\SplFileInfo $file): Book
     {
         $book = $this->bookRepository->findOneBy(
             [
@@ -183,6 +187,6 @@ class BookManager
         $checksum = $this->fileSystemManager->getFileChecksum($file);
         $book = $this->bookRepository->findOneBy(['checksum' => $checksum]);
 
-        return null === $book ? $this->createBook($file, $io) : $this->updateBookLocation($book, $file);
+        return null === $book ? $this->createBook($file) : $this->updateBookLocation($book, $file);
     }
 }


### PR DESCRIPTION
## Proposed changes

When a book fails the scan it's hard to figure out which book actually failed.
This change should make the error message clearer and help track down the issue.


## Checklist
- [ ] Tests are passing
- [ ] New tests have been written
- [ ] Documentation has been updated
- [ ] Translations have been updated
- [ ] Breaking changes have been avoided or documented

