### PR TITLE
Improve information hierarchy on book page

### DIFF
--- a/src/Controller/BookController.php
+++ b/src/Controller/BookController.php
@@ -50,6 +50,9 @@ class BookController extends AbstractController
             ], 301);
         }
 
+        /** @var User $user */
+        $user = $this->getUser();
+
         $form = $this->createFormBuilder(options: ['label_translation_prefix' => 'book.form.'])
             ->setAction($this->generateUrl('app_book_delete', [
                 'id' => $book->getId(),
@@ -97,15 +100,12 @@ class BookController extends AbstractController
 
         $interaction = $manager->getRepository(BookInteraction::class)->findOneBy([
             'book' => $book,
-            'user' => $this->getUser(),
+            'user' => $user,
         ]);
 
         return $this->render('book/index.html.twig', [
             'book' => $book,
-            'shelves' => array_filter(
-                $shelfRepository->findBy(['user' => $this->getUser()]),
-                fn ($shelf) => !$shelf->isDynamic()
-            ),
+            'shelves' => $shelfRepository->findManualShelvesForUser($user),
             'serie' => $serie,
             'serieMax' => $serieMax,
             'sameAuthor' => $sameAuthorBooks,

--- a/src/Controller/BookController.php
+++ b/src/Controller/BookController.php
@@ -102,7 +102,10 @@ class BookController extends AbstractController
 
         return $this->render('book/index.html.twig', [
             'book' => $book,
-            'shelves' => $shelfRepository->findBy(['user' => $this->getUser()]),
+            'shelves' => array_filter(
+                $shelfRepository->findBy(['user' => $this->getUser()]),
+                fn ($shelf) => !$shelf->isDynamic()
+            ),
             'serie' => $serie,
             'serieMax' => $serieMax,
             'sameAuthor' => $sameAuthorBooks,

--- a/src/Controller/BookController.php
+++ b/src/Controller/BookController.php
@@ -6,6 +6,7 @@ use App\Entity\Book;
 use App\Entity\BookInteraction;
 use App\Entity\User;
 use App\Repository\BookRepository;
+use App\Repository\ShelfRepository;
 use App\Security\Voter\BookVoter;
 use App\Security\Voter\RelocationVoter;
 use App\Service\BookFileSystemManagerInterface;
@@ -31,7 +32,7 @@ class BookController extends AbstractController
     }
 
     #[Route('/{book}/{slug}', name: 'app_book')]
-    public function index(Book $book, string $slug, BookRepository $bookRepository, EntityManagerInterface $manager, BookFileSystemManagerInterface $fileSystemManager): Response
+    public function index(Book $book, string $slug, BookRepository $bookRepository, EntityManagerInterface $manager, BookFileSystemManagerInterface $fileSystemManager, ShelfRepository $shelfRepository): Response
     {
         if ($slug !== $book->getSlug()) {
             return $this->redirectToRoute('app_book', [
@@ -101,6 +102,7 @@ class BookController extends AbstractController
 
         return $this->render('book/index.html.twig', [
             'book' => $book,
+            'shelves' => $shelfRepository->findBy(['user' => $this->getUser()]),
             'serie' => $serie,
             'serieMax' => $serieMax,
             'sameAuthor' => $sameAuthorBooks,

--- a/src/Entity/Shelf.php
+++ b/src/Entity/Shelf.php
@@ -137,6 +137,11 @@ class Shelf
         $this->slug = $slug;
     }
 
+    public function isDynamic(): bool
+    {
+        return $this->queryString !== null;
+    }
+
     public function getQueryString(): ?string
     {
         return $this->queryString;

--- a/src/Menu/MenuBuilder.php
+++ b/src/Menu/MenuBuilder.php
@@ -89,7 +89,7 @@ final class MenuBuilder
         if ($user->getShelves()->count() > 0) {
             foreach ($user->getShelves() as $shelf) {
                 /** @var Shelf $shelf */
-                if ($shelf->getQueryString() !== null) {
+                if ($shelf->isDynamic()) {
                     $shelves->addChild($shelf->getSlug(), ['label' => $shelf->getName(), 'route' => 'app_allbooks', 'routeParameters' => ['page' => 1, 'filterQuery' => $shelf->getQueryFilter(), 'orderQuery' => $shelf->getQueryOrder(), 'query' => $shelf->getQueryString()], ...$this->defaultAttr])
                         ->setExtra('icon', 'bookmark-fill')->setExtra('translation_domain', false);
                 } else {

--- a/src/Repository/ShelfRepository.php
+++ b/src/Repository/ShelfRepository.php
@@ -4,6 +4,7 @@ namespace App\Repository;
 
 use App\Entity\KoboDevice;
 use App\Entity\Shelf;
+use App\Entity\User;
 use App\Kobo\SyncToken;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\ORM\NonUniqueResultException;
@@ -39,6 +40,21 @@ class ShelfRepository extends ServiceEntityRepository
         $result = $qb->getQuery()->getOneOrNullResult();
 
         return $result;
+    }
+
+    /**
+     * @return Shelf[]
+     */
+    public function findManualShelvesForUser(User $user): array
+    {
+        $qb = $this->createQueryBuilder('shelf')
+            ->select('shelf')
+            ->where('shelf.user = :user')
+            ->setParameter('user', $user)
+            ->andWhere('shelf.queryFilter is null')
+            ->andWhere('shelf.queryString is null');
+
+        return $qb->getQuery()->getResult();
     }
 
     public function findByKoboAndName(KoboDevice $koboDevice, string $name): ?Shelf

--- a/src/Twig/Components/InlineEditInteraction.php
+++ b/src/Twig/Components/InlineEditInteraction.php
@@ -36,6 +36,7 @@ class InlineEditInteraction extends AbstractController
 
     public ?string $flashMessage = null;
     public ?string $flashMessageFav = null;
+    public ?string $flashMessageHidden = null;
 
     public function __construct(private EntityManagerInterface $entityManager, private FormFactoryInterface $formFactory)
     {
@@ -127,6 +128,6 @@ class InlineEditInteraction extends AbstractController
         $entityManager->flush();
         $this->interaction = $interaction;
 
-        $this->flashMessageFav = 'Hidden';
+        $this->flashMessageHidden = 'Hidden';
     }
 }

--- a/templates/book/index.html.twig
+++ b/templates/book/index.html.twig
@@ -4,21 +4,6 @@
 
 {% block body %}
     <div class="row">
-        <div class="col-md-12">
-            <ul class="nav nav-tabs mb-2">
-                <li class="nav-item">
-                    <a class="nav-link active" aria-current="page" href="#">Details</a>
-                </li>
-                <li class="nav-item">
-                    <a class="nav-link" href="{{ asset('books/'~book.bookPath~book.bookFilename) }}"><i class="bi bi-file-earmark-arrow-down"></i> {{ 'book.download'|trans }} {{ book.extension }}</a>
-                </li>
-                <li class="nav-item d-none d-sm-block">
-                    <a class="nav-link" href="{{ path('app_book_read',{'book':book.id,'slug':book.slug}) }}"><i class="bi bi-file-earmark-arrow-up"></i>
-                        Read in browser
-                    </a>
-                </li>
-            </ul>
-        </div>
         <div class="col-md-3 col-xs-6 col-sm-6">
             {% if book.imageFilename is not null %}
                 <img src="{{ asset('covers/'~book.imagePath~book.imageFilename)|imagine_filter('big') }}" class="border rounded card-img-top w-100" alt="{{ 'book.picture-for-book'|trans }} {{ book.title }}">
@@ -27,9 +12,17 @@
             {% endif %}
             {{ include('book/_interaction.html.twig') }}
 
-            {% if not book.verified %}
-            {{ component('UploadBookPicture',{'book':book}) }}
-            {% endif %}
+            <div class="d-grid gap-2">
+                <a class="btn btn-block btn-primary" href="{{ path('app_book_read',{'book':book.id,'slug':book.slug}) }}">
+                    <i class="bi bi-book"></i>
+                    Read in browser
+                </a>
+
+                <a class="btn btn-block btn-secondary" href="{{ asset('books/'~book.bookPath~book.bookFilename) }}">
+                    <i class="bi bi-file-earmark-arrow-down"></i> {{ 'book.download'|trans }} {{ book.extension }}
+                </a>
+            </div>
+
             {{ component('AddBookToShelf',{'book':book, 'user':app.user}) }}
         </div>
         <div class="col-md-9">
@@ -110,6 +103,9 @@
                                 {% endif %}
                                 <li>
                                     <a href="{{ path('app_extractCover', {'id':book.id}) }}">{{ 'book.extract-cover-from-file'|trans }}</a>
+                                </li>
+                                <li>
+                                    {{ component('UploadBookPicture',{'book':book}) }}
                                 </li>
                             </ul>
                         </td>

--- a/templates/book/index.html.twig
+++ b/templates/book/index.html.twig
@@ -23,7 +23,7 @@
                 </a>
             </div>
 
-            {{ component('AddBookToShelf',{'book':book, 'user':app.user}) }}
+            {{ component('AddBookToShelf',{'book':book, 'user':app.user, 'shelves': shelves}) }}
         </div>
         <div class="col-md-9">
             <table class="table w-100  mb-5">

--- a/templates/components/AddBookToShelf.html.twig
+++ b/templates/components/AddBookToShelf.html.twig
@@ -1,31 +1,33 @@
 <div {{ attributes.defaults(stimulus_controller('inline-edit')) }}>
-    <h6 class="mt-4">{{ "shelf.shelves"|trans }}</h6>
-    <div class="btn-group-vertical w-100">
-        {% for shelf in shelves %}
+    {% if book.shelves is not empty %}
+        <h6 class="mt-4">{{ "shelf.shelves"|trans }}</h6>
+        <div class="btn-group-vertical w-100">
+            {% for shelf in shelves %}
 
-                {% if shelf in book.shelves %}
-                    <button
-                        data-action="live#action"
-                        data-live-action-param="remove(shelfId={{ shelf.id }})"
-                        data-live-shelf-param="{{ shelf.id }}"
-                        class="btn btn-success btn-sm w-100"
-                        title="{{shelf.name}}"
-                    >
-                        {{ shelf.name }}
-                    </button>
-                {% else %}
-                    <button
+                    {% if shelf in book.shelves %}
+                        <button
                             data-action="live#action"
-                            data-live-action-param="add(shelfId={{ shelf.id }})"
+                            data-live-action-param="remove(shelfId={{ shelf.id }})"
                             data-live-shelf-param="{{ shelf.id }}"
-                            class="btn btn-outline-primary btn-sm w-100"
+                            class="btn btn-success btn-sm w-100"
                             title="{{shelf.name}}"
-                    >
-                        {{ shelf.name }}
-                    </button>
-                {% endif %}
-        {% endfor %}
-    </div>
+                        >
+                            {{ shelf.name }}
+                        </button>
+                    {% else %}
+                        <button
+                                data-action="live#action"
+                                data-live-action-param="add(shelfId={{ shelf.id }})"
+                                data-live-shelf-param="{{ shelf.id }}"
+                                class="btn btn-outline-primary btn-sm w-100"
+                                title="{{shelf.name}}"
+                        >
+                            {{ shelf.name }}
+                        </button>
+                    {% endif %}
+            {% endfor %}
+        </div>
+    {% endif %}
     {% if flashMessage %}
         <div class="alert-remove">
             <i class="bi bi-check"></i> {{ flashMessage }}

--- a/templates/components/AddBookToShelf.html.twig
+++ b/templates/components/AddBookToShelf.html.twig
@@ -1,5 +1,5 @@
 <div {{ attributes.defaults(stimulus_controller('inline-edit')) }}>
-    {% if book.shelves is not empty %}
+    {% if shelves is not empty %}
         <h6 class="mt-4">{{ "shelf.shelves"|trans }}</h6>
         <div class="btn-group-vertical w-100">
             {% for shelf in shelves %}

--- a/templates/components/InlineEditInteraction.html.twig
+++ b/templates/components/InlineEditInteraction.html.twig
@@ -54,9 +54,9 @@
         class="btn btn-link btn-sm text-{{ hidden?'success':'secondary' }} text-decoration-none"
         title="Click to toggle hidden status"
     >
-        <i class="bi bi-trash-fill"></i>
-        {% if flashMessageFav %}
-            <small class="text-muted alert-remove">{{ flashMessageFav }}</small>
+        <i class="bi bi-eye{{ hidden?'':'-slash' }}-fill"></i>
+        {% if flashMessageHidden %}
+            <small class="text-muted alert-remove">{{ flashMessageHidden }}</small>
         {% endif %}
 
     </button>

--- a/translations/messages+intl-icu.en.yaml
+++ b/translations/messages+intl-icu.en.yaml
@@ -44,7 +44,7 @@ book.age-category: Age category
 book.all-books: All books
 book.and-rename: and rename
 book.author: author
-book.authors: authors
+book.authors: Authors
 book.back-to: back to
 book.book-details: Book details
 book.book-path: Book path
@@ -68,7 +68,7 @@ book.publisher: Publisher
 book.read-state: Read state
 book.relocate: Relocate
 book.search-google-images: Search cover with Google Images
-book.serie: serie
+book.serie: Serie
 book.serieIndex: Serie Index
 book.size: Size
 book.summary: Summary


### PR DESCRIPTION
## Proposed changes

Even with the upcoming design I wanted to propose some improvements to the book page that are only improving the information hierarchy

Before:
<img width="1208" alt="Capture d’écran 2025-01-18 à 11 45 40" src="https://github.com/user-attachments/assets/b1d9bbe4-ad7e-4b26-9afe-0caee273d4db" />

After:
<img width="1083" alt="Capture d’écran 2025-01-18 à 12 32 40" src="https://github.com/user-attachments/assets/34832ebf-e333-4491-8856-87327494f180" />

A summary of the changes:
- The download and read book links are now big buttons under the covers instead of the tab-like navigation on top
- The "upload cover" button is now part of the utilities along with the "extract cover from file" link
- Changed the translation for "Authors" and "Serie" that were lowercase
- changed the "trash" icon of the "hide book" action for an "eye" icon that makes it clearer what this is

## Checklist
- [ ] Tests are passing
- [ ] New tests have been written
- [ ] Documentation has been updated
- [x] Translations have been updated
- [x] Breaking changes have been avoided or documented

