### PR TITLE
kobo(fix): Syncing multiple time must preserve the amount of synced book

### DIFF
--- a/migrations/Version20250128213230.php
+++ b/migrations/Version20250128213230.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20250128213230 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Remove duplicate synced books';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('
+            DELETE FROM kobo_synced_book
+            WHERE id NOT IN (
+                SELECT id FROM (
+                    SELECT MAX(id) AS id
+                    FROM kobo_synced_book
+                    GROUP BY book_id, kobo_device_id
+                ) AS subquery
+            )
+        ');
+    }
+
+    public function down(Schema $schema): void
+    {
+    }
+}

--- a/migrations/Version20250128214238.php
+++ b/migrations/Version20250128214238.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20250128214238 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add unique constraint to kobo_synced_book';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('CREATE UNIQUE INDEX kobo_synced_book_unique ON kobo_synced_book (book_id, kobo_device_id)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP INDEX kobo_synced_book_unique ON kobo_synced_book');
+    }
+}

--- a/src/Entity/KoboSyncedBook.php
+++ b/src/Entity/KoboSyncedBook.php
@@ -8,6 +8,7 @@ use Doctrine\ORM\Mapping as ORM;
 use Gedmo\Mapping\Annotation as Gedmo;
 
 #[ORM\Entity(repositoryClass: KoboSyncedBookRepository::class)]
+#[ORM\UniqueConstraint(name: 'kobo_synced_book_unique', columns: ['book_id', 'kobo_device_id'])]
 class KoboSyncedBook
 {
     #[ORM\Id]

--- a/src/Repository/KoboSyncedBookRepository.php
+++ b/src/Repository/KoboSyncedBookRepository.php
@@ -34,39 +34,40 @@ class KoboSyncedBookRepository extends ServiceEntityRepository
         $updatedAt = $syncToken->lastModified ?? new \DateTime();
         $createdAt = $syncToken->lastCreated ?? new \DateTime();
 
-        $qb = $this->createQueryBuilder('koboSyncedBook')
+        $syncedBooksQuery = $this->createQueryBuilder('koboSyncedBook')
              ->select('book.id')
+             ->distinct()
              ->join('koboSyncedBook.book', 'book')
              ->where('koboSyncedBook.koboDevice = :koboDevice')
              ->andWhere('koboSyncedBook.book IN (:books)')
              ->setParameter('koboDevice', $koboDevice)
              ->setParameter('books', $books)
         ;
-        $updatedBooks = (array) $qb
+        $updatedBooks = (array) $syncedBooksQuery
             ->getQuery()->getResult(AbstractQuery::HYDRATE_ARRAY);
 
-        $qb->update()
+        $syncedBooksQuery->update()
             ->set('koboSyncedBook.updated', ':updatedAt')
             ->setParameter('updatedAt', $updatedAt)
         ->getQuery()
             ->execute();
 
         /** @var array<int, Book> $books */
-        $qb1 = $this->createQueryBuilder('koboSyncedBook')
+        $booksToSyncQuery = $this->createQueryBuilder('koboSyncedBook')
             ->resetDQLPart('select')
             ->resetDQLPart('from')
             ->from(Book::class, 'book')
             ->select('book')
-            ->where($qb->expr()->in('book.id', ':booksIds'))
+            ->where($syncedBooksQuery->expr()->in('book.id', ':booksIds'))
             ->setParameter('booksIds', array_map(fn (Book $book) => $book->getId(), $books));
 
         if ($updatedBooks !== []) {
-            $qb->andWhere($qb->expr()->notIn('book.id', ':excludedIds'))
+            $booksToSyncQuery->andWhere($syncedBooksQuery->expr()->notIn('book.id', ':excludedIds'))
                 ->setParameter('excludedIds', $updatedBooks);
         }
 
         /** @var Book[] $books */
-        $books = $qb1
+        $books = $booksToSyncQuery
             ->getQuery()->getResult();
 
         foreach ($books as $book) {


### PR DESCRIPTION
## Proposed changes

- Fix: If you sync multiple times, the amount of SyncedBook should not increase.



## Checklist
- [x] Tests are passing
- [x] New tests have been written
