### PR TITLE
feat(groups): Paginate result and filter with digits

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "biblioteca",
+  "name": "html",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/src/Controller/GroupController.php
+++ b/src/Controller/GroupController.php
@@ -14,16 +14,12 @@ class GroupController extends AbstractController
     {
     }
 
-    #[Route('/{type}/{letter}/{page}', name: 'app_groups', defaults: ['page' => 1], requirements: ['page' => '\d+', 'letter' => '[a-zA-Z]|alpha|$^'])]
+    #[Route('/{type}/{letter}/{page}', name: 'app_groups', defaults: ['page' => 1], requirements: ['page' => '\d+', 'letter' => '[a-zA-Z0-9]|alpha|$^'])]
     public function groups(Request $request, string $type, int $page, ?string $letter = null): Response
     {
         $group = [];
         $count = 0;
         $letter = trim((string) $letter) === '' ? null : strtolower((string) $letter);
-
-        if ($letter !== null && preg_match('/^[a-z0-9]|alpha$/', $letter) !== 1) {
-            return $this->redirectToRoute('app_groups', ['type' => $type, 'letter' => null]);
-        }
         $page = $letter === null ? $page : null; // Paginate except if filtered
         $perPage = 50;
 

--- a/templates/group/index.html.twig
+++ b/templates/group/index.html.twig
@@ -8,7 +8,7 @@
         {{ type }} - {{ letter|upper }}
     </div>
 
-    <form method="get" class="form-inline my-2">
+    <form method="get" class="form-inline my-2" action="{{ path('app_groups', {'type':type, 'letter': null, 'page': 1}) }}">
         <div class="input-group">
             <input type="text" name="search" id="search" class="form-control" placeholder="{{ "group.filter-placeholder"|trans }}" value="{{ search }}">
             <button type="submit" class="btn btn-primary">{{ 'group.search'|trans }}</button>
@@ -16,9 +16,11 @@
     </form>
 
     <div class="btn-group btn-group-sm">
-    {% for other_letter in "a".."z" %}
-        <a href="{{ path('app_groups', {'type':type, 'letter': other_letter}) }}" class="btn {{ other_letter==letter?'btn-primary':'btn-outline-primary' }}">{{ other_letter|upper }}</a>
-    {% endfor %}
+        <a href="{{ path('app_groups', {'type':type, 'page': '1'}) }}" class="btn btn-cross"><i class="bi bi-clipboard-x"></i></a>
+        <a href="{{ path('app_groups', {'type':type, 'letter': 'alpha'}) }}" class="btn {{ 'alpha'==letter?'btn-primary':'btn-outline-primary' }}">{{ '0-9'|upper }}</a>
+        {% for other_letter in "a".."z" %}
+            <a href="{{ path('app_groups', {'type':type, 'letter': other_letter}) }}" class="btn {{ other_letter==letter?'btn-primary':'btn-outline-primary' }}">{{ other_letter|upper }}</a>
+        {% endfor %}
     </div>
         <ul class="list-unstyled my-3">
             {% for item in group %}
@@ -41,5 +43,13 @@
                 </li>
             {% endfor %}
         </ul>
+
+    {% if page is not null %}
+        <div class="btn-group btn-group-sm">
+            {% for pageNum in 1..total %}
+                <a href="{{ path('app_groups', {'type':type, 'page': pageNum, 'letter': letter}) }}" class="btn {{ pageNum==page?'btn-primary':'btn-outline-primary' }}">{{ pageNum }}</a>
+            {% endfor %}
+        </div>
+    {% endif %}
 
 {% endblock %}


### PR DESCRIPTION
## Proposed changes
* By default, the group page doesn't filter by "A" but paginate.
* Once you selected a filter like "A" it's not paginated anymore.
* A new filter "[0-9]" is available, and a button to clear the filters too.

![image](https://github.com/user-attachments/assets/de6f6d35-551d-48f1-931a-c801a7ccc47f)



## Checklist
- [ ] Translations have been updated => Add title on "clear filter" ?
- [x] Breaking changes have been avoided or documented => URL ?
- [ ] fix sort by & count mismatch
- [ ] more test and coverage 

