### PR TITLE
chore(deps): Upgrade to typesense 28

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "ext-imagick": "*",
     "ext-zip": "*",
     "beberlei/doctrineextensions": "^1.3",
-    "biblioverse/typesense-bundle": "^0.0.4",
+    "biblioverse/typesense-bundle": "^0.0.6",
     "devdot/monolog-parser": "^1.6",
     "doctrine/annotations": "^2.0.2",
     "doctrine/doctrine-bundle": "^2.13.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4303e1483ef90fe5f60e6c53b3af9b85",
+    "content-hash": "f46f453b185ce885a1fd03d60fa0d326",
     "packages": [
         {
             "name": "beberlei/doctrineextensions",
@@ -119,30 +119,31 @@
         },
         {
             "name": "biblioverse/typesense-bundle",
-            "version": "v0.0.4",
+            "version": "v0.0.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/biblioverse/TypesenseBundle.git",
-                "reference": "c8c00d26f306179aa41dcf5bc24266ce94c82b01"
+                "reference": "a8ce02c17f0352f4c0a70a599641749bd0434cf6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/biblioverse/TypesenseBundle/zipball/c8c00d26f306179aa41dcf5bc24266ce94c82b01",
-                "reference": "c8c00d26f306179aa41dcf5bc24266ce94c82b01",
+                "url": "https://api.github.com/repos/biblioverse/TypesenseBundle/zipball/a8ce02c17f0352f4c0a70a599641749bd0434cf6",
+                "reference": "a8ce02c17f0352f4c0a70a599641749bd0434cf6",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1",
+                "php": ">=8.2",
                 "php-http/discovery": "^1.20",
                 "psr/http-client": "^1.0",
                 "psr/http-client-implementation": "1.0",
+                "psr/http-factory": "^1.0",
                 "psr/log": "^3.0",
                 "symfony/framework-bundle": "^6.4|^7.0",
                 "symfony/http-client": "^6.4.18|^7.2",
                 "symfony/http-kernel": "^6.4|^7.2",
                 "symfony/property-access": "^6.4|^7.2",
                 "symfony/service-contracts": "^3.5",
-                "typesense/typesense-php": "^4.9"
+                "typesense/typesense-php": "^4.9|^5.0"
             },
             "conflict": {
                 "php-http/httplug": "<1.5"
@@ -152,9 +153,11 @@
                 "doctrine/doctrine-fixtures-bundle": "^4.0",
                 "doctrine/orm": "^3.3",
                 "friendsofphp/php-cs-fixer": "dev-master",
+                "phpstan/extension-installer": "^1.4",
                 "phpstan/phpstan": "^2.1.2",
+                "phpstan/phpstan-phpunit": "^2.0",
                 "phpstan/phpstan-symfony": "^2.0",
-                "phpunit/phpunit": "^10.0|^11.5|^12.0",
+                "phpunit/phpunit": "^11.5|^12.0",
                 "rector/rector": "^2.0.8",
                 "symfony/console": "^6.4|^7.2",
                 "symfony/dotenv": "^6.4|^7.2",
@@ -229,10 +232,10 @@
             },
             "description": "This bundle provides integration with Typesense in Symfony",
             "support": {
-                "source": "https://github.com/biblioverse/TypesenseBundle/tree/v0.0.4",
+                "source": "https://github.com/biblioverse/TypesenseBundle/tree/v0.0.6",
                 "issues": "https://github.com/biblioverse/TypesenseBundle/issues"
             },
-            "time": "2025-02-08T16:58:05+00:00"
+            "time": "2025-02-25T22:31:28+00:00"
         },
         {
             "name": "clue/stream-filter",
@@ -11252,16 +11255,16 @@
         },
         {
             "name": "typesense/typesense-php",
-            "version": "v4.9.3",
+            "version": "v5.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/typesense/typesense-php.git",
-                "reference": "50fc2089ff4829c8e0e11d8c674e9da085b49998"
+                "reference": "513270e6a124101c25b03ee27598efd6b87fbec0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/typesense/typesense-php/zipball/50fc2089ff4829c8e0e11d8c674e9da085b49998",
-                "reference": "50fc2089ff4829c8e0e11d8c674e9da085b49998",
+                "url": "https://api.github.com/repos/typesense/typesense-php/zipball/513270e6a124101c25b03ee27598efd6b87fbec0",
+                "reference": "513270e6a124101c25b03ee27598efd6b87fbec0",
                 "shasum": ""
             },
             "require": {
@@ -11277,6 +11280,8 @@
                 "psr/http-message": "^1.0 || ^2.0"
             },
             "require-dev": {
+                "mockery/mockery": "^1.6",
+                "phpunit/phpunit": "^11.2",
                 "squizlabs/php_codesniffer": "3.*",
                 "symfony/http-client": "^5.2"
             },
@@ -11317,7 +11322,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-04-29T15:34:34+00:00"
+            "time": "2025-02-24T21:13:28+00:00"
         },
         {
             "name": "webmozart/assert",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,7 +49,7 @@ services:
       - default
 
   typesense:
-      image: typesense/typesense:27.1
+      image: typesense/typesense:28.0
       restart: on-failure
       ports:
         - 8983


### PR DESCRIPTION
- [x] fix   Call to undefined method Symfony\Component\HttpClient\Psr18Client::send()  

Probably an upstream issue again regarding PSR18. 
1. I reported the issue https://github.com/typesense/typesense-php/issues/77
2. Made a hack on typesense-bundle, but need to release it.