### PR TITLE
Hotfix/236 Upstream Synctoken

### DIFF
--- a/src/Controller/Kobo/KoboDeviceController.php
+++ b/src/Controller/Kobo/KoboDeviceController.php
@@ -75,7 +75,7 @@ class KoboDeviceController extends AbstractController
             throw $this->createAccessDeniedException('You don\'t have permission to edit this koboDevice');
         }
 
-        $form = $this->createForm(KoboType::class, $koboDevice);
+        $form = $this->createForm(KoboType::class, $koboDevice, ['show_last_sync_token' => true]);
         $form->handleRequest($request);
 
         if ($form->isSubmitted() && $form->isValid()) {
@@ -88,6 +88,19 @@ class KoboDeviceController extends AbstractController
             'kobo' => $koboDevice,
             'form' => $form,
         ]);
+    }
+
+    #[Route('/{id}/reset-sync-token', name: 'app_kobodevice_reset_sync_token')]
+    public function resetSyncToken(Request $request, KoboDevice $koboDevice, EntityManagerInterface $entityManager): Response
+    {
+        if (!$this->isGranted('EDIT', $koboDevice)) {
+            throw $this->createAccessDeniedException('You don\'t have permission to edit this koboDevice');
+        }
+
+        $koboDevice->setLastSyncToken(null);
+        $entityManager->flush();
+
+        return $this->redirect($request->headers->get('referer') ?? '/');
     }
 
     #[Route('/{id}', name: 'app_kobodevice_user_delete', methods: ['POST'])]

--- a/src/Entity/KoboDevice.php
+++ b/src/Entity/KoboDevice.php
@@ -20,8 +20,8 @@ class KoboDevice
     use RandomGeneratorTrait;
     public const KOBO_DEVICE_ID_HEADER = 'X-Kobo-Deviceid';
     public const KOBO_DEVICE_MODEL_HEADER = 'X-Kobo-Devicemodel';
-    public const KOBO_SYNC_TOKEN_HEADER = 'kobo-synctoken';
-    public const KOBO_SYNC_SHOULD_CONTINUE_HEADER = 'x-kobo-sync';
+    public const KOBO_SYNC_TOKEN_HEADER = 'X-Kobo-Synctoken';
+    public const KOBO_SYNC_SHOULD_CONTINUE_HEADER = 'X-Kobo-Sync';
     public const KOBO_SYNC_MODE = 'X-Kobo-Sync-Mode';
 
     #[ORM\Id]

--- a/src/Form/KoboLastSyncTokenType.php
+++ b/src/Form/KoboLastSyncTokenType.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Form;
+
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class KoboLastSyncTokenType extends TextType
+{
+    #[\Override]
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults([
+            'disabled' => true,
+            'attr' => [
+                'readonly' => true,
+                'disabled' => true,
+            ],
+        ]);
+    }
+}

--- a/src/Form/KoboType.php
+++ b/src/Form/KoboType.php
@@ -34,18 +34,28 @@ class KoboType extends AbstractType
             ->add('model', null, [
                 'disabled' => true,
                 'required' => false,
-            ])
-            ->add('forceSync', null, [
-                'required' => false,
-            ])
+            ]);
+
+        if (is_bool($options['show_last_sync_token']) && $options['show_last_sync_token']) {
+            $builder->add('lastSyncToken', KoboLastSyncTokenType::class);
+        }
+
+        $builder->add('forceSync', null, [
+            'required' => false,
+            'help' => 'kobo.form.force_sync_help',
+        ])
             ->add('upstreamSync', null, [
                 'required' => false,
+                'help' => 'kobo.form.upstreamsync_help',
                 'disabled' => !$this->koboProxyConfiguration->useProxy(),
             ])->add('syncReadingList', null, [
                 'required' => false,
+                'help' => 'kobo.form.syncreadinglist_help',
             ]);
+
         $builder->add('shelves', EntityType::class, [
             'class' => Shelf::class,
+            'help' => 'kobo.form.shelvessync_help',
             'query_builder' => fn (EntityRepository $er): QueryBuilder => $er->createQueryBuilder('u')
                 ->setParameter('user', $this->security->getUser())
                 ->andWhere('u.user = :user'),
@@ -60,6 +70,7 @@ class KoboType extends AbstractType
     public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
+            'show_last_sync_token' => false,
             'data_class' => KoboDevice::class,
             'label_translation_prefix' => 'kobo.form.',
         ]);

--- a/src/Kobo/Response/SyncResponse.php
+++ b/src/Kobo/Response/SyncResponse.php
@@ -68,10 +68,10 @@ class SyncResponse
         return array_filter($list, fn ($item) => $item !== []);
     }
 
-    public function toJsonResponse(bool $shouldContinue): JsonResponse
+    public function toJsonResponse(bool $shouldContinue, ?JsonResponse $response = null): JsonResponse
     {
         $list = $this->getData();
-        $response = new JsonResponse();
+        $response ??= new JsonResponse();
         $response->setContent($this->serializer->serialize($list, 'json', [DateTimeNormalizer::FORMAT_KEY => self::DATE_FORMAT]));
 
         $response->headers->set(KoboDevice::KOBO_SYNC_SHOULD_CONTINUE_HEADER, $shouldContinue ? 'continue' : 'done');

--- a/src/Kobo/SyncToken.php
+++ b/src/Kobo/SyncToken.php
@@ -5,7 +5,7 @@ namespace App\Kobo;
 use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
-class SyncToken
+class SyncToken implements \Stringable
 {
     public string $version = '1-1-0';
     public ?\DateTimeImmutable $lastModified = null;
@@ -107,6 +107,11 @@ class SyncToken
             'tagLastModified' => $this->tagLastModified?->format($format),
             'version' => $this->version,
         ];
+    }
+
+    public function __toString(): string
+    {
+        return json_encode($this->toArray(), JSON_THROW_ON_ERROR);
     }
 
     public function markLastSyncDateAndResetPage(): self

--- a/src/Kobo/SyncToken.php
+++ b/src/Kobo/SyncToken.php
@@ -20,19 +20,28 @@ class SyncToken implements \Stringable
 
     public static function fromArray(array $lastSyncToken): SyncToken
     {
-        $fromAtom = fn (?string $date): ?\DateTimeImmutable => $date !== null ? new \DateTimeImmutable($date) : null;
-        $token = new self();
-        $token->version = $lastSyncToken['version'] ?? $token->version;
-        $token->lastModified = $fromAtom($lastSyncToken['lastModified'] ?? null);
-        $token->lastCreated = $fromAtom($lastSyncToken['lastCreated'] ?? null);
-        $token->archiveLastModified = $fromAtom($lastSyncToken['archiveLastModified'] ?? null);
-        $token->readingStateLastModified = $fromAtom($lastSyncToken['readingStateLastModified'] ?? null);
-        $token->tagLastModified = $fromAtom($lastSyncToken['tagLastModified'] ?? null);
-        $token->rawKoboStoreToken = $lastSyncToken['rawKoboStoreToken'] ?? $token->rawKoboStoreToken;
-        $token->filters = $lastSyncToken['filters'] ?? $token->filters;
-        $token->page = $lastSyncToken['page'] ?? 1;
+        return self::copy($lastSyncToken, new self());
+    }
 
-        return $token;
+    private static function copy(array $lastSyncToken, SyncToken $destination): SyncToken
+    {
+        $fromAtom = fn (?string $date): ?\DateTimeImmutable => $date !== null ? new \DateTimeImmutable($date) : null;
+        $destination->version = $lastSyncToken['version'] ?? $destination->version;
+        $destination->lastModified = $fromAtom($lastSyncToken['lastModified'] ?? null);
+        $destination->lastCreated = $fromAtom($lastSyncToken['lastCreated'] ?? null);
+        $destination->archiveLastModified = $fromAtom($lastSyncToken['archiveLastModified'] ?? null);
+        $destination->readingStateLastModified = $fromAtom($lastSyncToken['readingStateLastModified'] ?? null);
+        $destination->tagLastModified = $fromAtom($lastSyncToken['tagLastModified'] ?? null);
+        $destination->rawKoboStoreToken = $lastSyncToken['rawKoboStoreToken'] ?? $destination->rawKoboStoreToken;
+        $destination->filters = $lastSyncToken['filters'] ?? $destination->filters;
+        $destination->page = $lastSyncToken['page'] ?? 1;
+
+        return $destination;
+    }
+
+    public function override(SyncToken $lastSyncToken): self
+    {
+        return self::copy($lastSyncToken->toArray(), $this);
     }
 
     public function getFilterResolver(): OptionsResolver

--- a/src/Service/KoboSyncTokenExtractor.php
+++ b/src/Service/KoboSyncTokenExtractor.php
@@ -31,7 +31,7 @@ class KoboSyncTokenExtractor
     }
 
     /**
-     * @return array{'HTTP_kobo-synctoken': string}
+     * @return array{'HTTP_X-Kobo-Synctoken': string}
      * @throws \JsonException
      */
     public function getTestHeader(SyncToken $token): array

--- a/templates/kobodevice_user/_form.html.twig
+++ b/templates/kobodevice_user/_form.html.twig
@@ -1,3 +1,4 @@
+{% form_theme form 'kobodevice_user/_form_theme.html.twig' %}
 {{ form_start(form) }}
     {{ form_widget(form) }}
     <button class="btn btn-primary">{{ button_label|default('generic.save')|trans }}</button>

--- a/templates/kobodevice_user/_form_theme.html.twig
+++ b/templates/kobodevice_user/_form_theme.html.twig
@@ -1,0 +1,9 @@
+{% block _kobo_lastSyncToken_widget %}
+    {{ block('form_widget_simple') }}
+
+    {%  if form.parent.vars.data.id|default(false) and data is not null %}
+    <a href="{{ path('app_kobodevice_reset_sync_token', {'id': form.parent.vars.data.id}) }}" class="btn btn-secondary mt-2">
+        {{ 'kobo.form.reset-sync-token'|trans }}
+    </a>
+    {%  endif %}
+{% endblock %}

--- a/templates/kobodevice_user/edit.html.twig
+++ b/templates/kobodevice_user/edit.html.twig
@@ -11,3 +11,5 @@
     {{ include('kobodevice_user/instructions.html.twig', { token: kobo.accessKey, open:true }) }}
 
 {% endblock %}
+
+

--- a/tests/Controller/Kobo/KoboControllerTestCase.php
+++ b/tests/Controller/Kobo/KoboControllerTestCase.php
@@ -21,12 +21,19 @@ abstract class KoboControllerTestCase extends WebTestCase
         self::createClient();
     }
 
-    protected static function getJsonResponse(): array
+    protected static function getRawResponse(): Response
     {
         self::assertInstanceOf(AbstractBrowser::class, self::getClient());
 
         /** @var Response $response */
         $response = self::getClient()->getResponse();
+
+        return $response;
+    }
+
+    protected static function getJsonResponse(): array
+    {
+        $response = self::getRawResponse();
         self::assertResponseIsSuccessful();
         $content = $response->getContent();
 

--- a/tests/TestCaseHelperTrait.php
+++ b/tests/TestCaseHelperTrait.php
@@ -73,10 +73,13 @@ trait TestCaseHelperTrait
         return $service;
     }
 
-    protected function getMockClient(string $returnValue, int $code = 200): ClientInterface
+    /**
+     * @param array<string,string> $headers
+     */
+    protected function getMockClient(string $returnValue, int $code = 200, array $headers = []): ClientInterface
     {
         $mock = new MockHandler([
-            new Response($code, ['Content-Type' => 'application/json'], $returnValue),
+            new Response($code, $headers + ['Content-Type' => 'application/json'], $returnValue),
         ]);
 
         $handlerStack = HandlerStack::create($mock);

--- a/translations/messages+intl-icu.en.yaml
+++ b/translations/messages+intl-icu.en.yaml
@@ -254,14 +254,20 @@ kobo.device.owner: Owner
 kobo.device.reader-settings: Kobo device settings
 kobo.device.shelves: Shelves
 kobo.device.title: Title
-kobo.form.accessKey: Access Key
-kobo.form.deviceId: Device Id
-kobo.form.forceSync: Force next synchronisation
+kobo.form.accesskey: Access Key
+kobo.form.deviceid: Device Id
+kobo.form.forcesync: Force next synchronisation
+kobo.form.force_sync_help: All your books will be synced again next time you sync your Kobo device.
 kobo.form.model: Kobo device model
 kobo.form.name: Name
 kobo.form.shelves: Synchronized Shelves
-kobo.form.syncReadingList: Synchronize reading list
-kobo.form.upstreamSync: Sync with official store
+kobo.form.syncreadinglist: Synchronize reading list
+kobo.form.syncreadinglist_help: Books in your reading list will be synced to your Kobo device.
+kobo.form.upstreamsync: Sync with official store
+kobo.form.upstreamsync_help: Books purchased from the official store will be synced to your library (experimental).
+kobo.form.reset-sync-token: Reset sync token
+kobo.form.lastsynctoken: Last sync token
+kobo.form.shelvessync_help: Books in the selected shelves will be synced to your Kobo device.
 kobo.logs.channel: Log Channel
 kobo.logs.date: Date
 kobo.logs.device: Device

--- a/translations/messages+intl-icu.fr.yaml
+++ b/translations/messages+intl-icu.fr.yaml
@@ -243,11 +243,16 @@ kobo.device.title: Titre
 kobo.form.accesskey: "Clé d'accès"
 kobo.form.deviceid: Identifiant
 kobo.form.forcesync: 'Forcer la prochaine synchronisation'
+kobo.form.force_sync_help: Tous vos livres seront synchronisés à nouveau la prochaine fois que vous synchroniserez votre appareil Kobo.
 kobo.form.model: "Modèle de l'appareil Kobo"
 kobo.form.name: Nom
 kobo.form.shelves: 'Etagères synchronisées'
-kobo.form.syncReadingList: 'Synchroniser la liste de lecture'
-kobo.form.upstreamSync: 'Synchroniser avec le store officiel'
+kobo.form.syncreadinglist: 'Synchroniser la liste de lecture'
+kobo.form.syncreadinglist_help: Les livres de votre liste de lecture seront synchronisés sur votre appareil Kobo.
+kobo.form.upstreamsync: 'Synchroniser avec le store officiel'
+kobo.form.upstreamsync_help: Les livres achetés dans le store officiel seront synchronisés dans votre bibliothèque (expérimental).
+kobo.form.reset-sync-token: "Réinitialiser le jeton de synchronisation"
+kobo.form.lastsynctoken: Dernier jeton de synchronisation
 kobo.logs.channel: 'Log Channel'
 kobo.logs.date: Date
 kobo.logs.device: Appareil


### PR DESCRIPTION
## Proposed changes

Syncing books is looping indefinetely when `upstreamsync` is enabled.
This is due to the header `Kobo-Synctoken` renamed to `X-Kobo-Synctoken`.

* Fixed cast in translations
* Added help messages in the Kobo Admin pannel
* Renamed header `X-Kobo-Synctoken`
* Added an option to remove the LastSyncToken from the admin.
* When upstreamsync is enabled, we use the upsteam synctoken instead of the locale one.



## Checklist
- [x] Tests are passing
- [x] New tests have been written
- [x] Documentation has been updated
- [x] Translations have been updated
- [x] Breaking changes have been avoided or documented

