### PR TITLE
Search and not-verified improvements

### DIFF
--- a/src/Twig/Components/Search.php
+++ b/src/Twig/Components/Search.php
@@ -35,6 +35,9 @@ class Search
     #[LiveProp(writable: true, url: true)]
     public string $orderQuery = 'updated:desc';
 
+    #[LiveProp(writable: true, url: true)]
+    public int $perPage = 20;
+
     public array $books = [];
     public array $facets = [];
 
@@ -113,9 +116,17 @@ class Search
         $this->getResults();
     }
 
+    #[LiveAction]
+    public function replacePerPage(#[LiveArg] int $value): void
+    {
+        $this->perPage = $value;
+        $this->page = 1;
+        $this->getResults();
+    }
+
     protected function getResults(): void
     {
-        $this->searchHelper->prepareQuery($this->query, $this->filterQuery, $this->orderQuery, page: $this->page);
+        $this->searchHelper->prepareQuery($this->query, $this->filterQuery, $this->orderQuery, $this->perPage, $this->page);
 
         try {
             $this->searchHelper->execute();
@@ -125,7 +136,7 @@ class Search
             // In case of filter-query error, remove "filterBy" and try again
             if ($e instanceof SearchException && $e->getPrevious() instanceof RequestMalformed) {
                 $this->filterQueryError = $e->getMessage();
-                $this->searchHelper->prepareQuery($this->query, '', $this->orderQuery, page: $this->page);
+                $this->searchHelper->prepareQuery($this->query, '', $this->orderQuery, $this->perPage, $this->page);
                 $this->searchHelper->execute();
             }
             $this->searchHelper->execute();

--- a/templates/book/index.html.twig
+++ b/templates/book/index.html.twig
@@ -85,11 +85,12 @@
             <div class="heroProgress">
                 {% set width = 0 %}
                 {% if interaction is not null and interaction.readPages >0 %}
-                    {% set width = ((interaction.readPages/book.pageNumber) *100) %}
+                    {% set pages = max(book.pageNumber, 1) %}
+                    {% set width = ((interaction.readPages/pages) *100) %}
 
                     {% if interaction.readPages > 0 %}
                     <div class="heroProgress__text">
-                    {{ 'books.reading.progress'|trans({"%read%": interaction.readPages, "%total%": book.pageNumber }) }}
+                    {{ 'books.reading.progress'|trans({"%read%": interaction.readPages, "%total%": pages }) }}
                     </div>
                     {% endif %}
                 {% endif %}

--- a/templates/components/Search.html.twig
+++ b/templates/components/Search.html.twig
@@ -64,14 +64,14 @@
 
         {% if books|length >0 or query!='' or filterQuery!=''  %}
 
-            <div class="results mt-4">
-                <div class="row">
+            <div class="results">
+                <div class="row my-4">
                     <div class="col">
                         {% set route='app_allbooks' %}
                         {% set params={'page':page, 'query': query, 'filterQuery':filterQuery, 'orderQuery':orderQuery} %}
                         {% set current= pagination.page %}
                         <nav aria-label="Navigate through results">
-                            <ul class="pagination">
+                            <ul class="pagination" style="margin:0">
                                 {% if pagination.previousPage is not null %}
                                     <li class="page-item">
                                         <a class="page-link" href="{{ path(route, params|merge({'page':pagination.previousPage})) }}">{{ "generic.previous"|trans }}</a>
@@ -120,7 +120,7 @@
                             </ul>
                         </nav>
                     </div>
-                    <div class="col text-end">
+                    <div class="col text-end d-flex justify-content-end" style="gap: var(--space--sm);">
                         <div class="dropdown">
                             <button class="btn btn-outline-primary dropdown-toggle" type="button" data-bs-toggle="dropdown" aria-expanded="false">
                                 <i class="bi bi-arrow-down-up"></i> {{ "search.sort-results"|trans }}
@@ -141,6 +141,22 @@
                                     {% endfor %}
                                 {% endfor %}
                             </ul>
+                        </div>
+
+                        <div class="btn-group" role="group" aria-label="Basic example">
+                            <button type="button" class="btn btn-outline-primary {{ perPage == 20 ?'active':''}} "
+                                data-action="live#action click->search#focus"
+                                data-live-action-param="replacePerPage"
+                                data-live-value-param='20'
+                            >20</button>
+                            <button type="button" class="btn btn-outline-primary {{ perPage == 50 ?'active':''}}"
+                                data-action="live#action click->search#focus"
+                                data-live-action-param="replacePerPage"
+                                data-live-value-param='50'>50</button>
+                            <button type="button" class="btn btn-outline-primary {{ perPage == 100 ?'active':''}}"
+                                data-action="live#action click->search#focus"
+                                data-live-action-param="replacePerPage"
+                                data-live-value-param='100'>100</button>
                         </div>
                     </div>
                 </div>

--- a/templates/components/Search.html.twig
+++ b/templates/components/Search.html.twig
@@ -144,19 +144,13 @@
                         </div>
 
                         <div class="btn-group" role="group" aria-label="Basic example">
-                            <button type="button" class="btn btn-outline-primary {{ perPage == 20 ?'active':''}} "
-                                data-action="live#action click->search#focus"
-                                data-live-action-param="replacePerPage"
-                                data-live-value-param='20'
-                            >20</button>
-                            <button type="button" class="btn btn-outline-primary {{ perPage == 50 ?'active':''}}"
-                                data-action="live#action click->search#focus"
-                                data-live-action-param="replacePerPage"
-                                data-live-value-param='50'>50</button>
-                            <button type="button" class="btn btn-outline-primary {{ perPage == 100 ?'active':''}}"
-                                data-action="live#action click->search#focus"
-                                data-live-action-param="replacePerPage"
-                                data-live-value-param='100'>100</button>
+                            {% for pageIncrement in [10,50,100] %}
+                            <button type="button" class="btn btn-outline-primary {{ perPage == pageIncrement ?'active':''}} "
+                                    data-action="live#action click->search#focus"
+                                    data-live-action-param="replacePerPage"
+                                    data-live-value-param='{{pageIncrement}}'
+                                >{{pageIncrement}}</button>
+                            {% endfor %}
                         </div>
                     </div>
                 </div>

--- a/templates/default/notverified.html.twig
+++ b/templates/default/notverified.html.twig
@@ -85,11 +85,11 @@
                         <code>{{ book.bookPath }}{{ book.bookFilename }}</code>
                     </td>
                     <td>
+                        <div class="my-1">
+                            {{ component('Assistant', {book: book}) }}
+                        </div>
+                        {{ component('InlineEditVerified',{'book':book}) }}
                         {% if not book.verified and is_granted('RELOCATE', book) %}
-                            <div class="my-1">
-                                {{ component('Assistant', {book: book}) }}
-                            </div>
-                            {{ component('InlineEditVerified',{'book':book}) }}
                             <a href="{{ path('app_book_relocate', {'id':book.id}) }}" class="btn btn-sm btn-outline-danger">{{ "book.relocate"|trans }}</a>
                         {% endif %}
                     </td>


### PR DESCRIPTION
## Proposed changes

* Allow to choose the number of items on a page (20, 50, 100), useful when we wish to mass-edit a lot of books from the search page
* Fix a bug that prevents books from being shown when the number of pages in the book is 0 (division by zero)
* Fix a bug that does not display the "edit" button in the "not verified" page

<img width="528" alt="image" src="https://github.com/user-attachments/assets/ca0538bc-9e37-4e28-98a0-1d97d75f9a72" />


## Checklist
- [ ] Tests are passing
- [ ] New tests have been written
- [ ] Documentation has been updated
- [ ] Translations have been updated
- [ ] Breaking changes have been avoided or documented

