### PR TITLE
chore(deps): update GitHub Actions to latest majors

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -14,12 +14,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v7
         with:
           go-version: 'stable'
 

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -22,17 +22,17 @@ jobs:
     steps:
   # Get the repository's code
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
       # https://github.com/docker/setup-qemu-action
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
       # https://github.com/docker/setup-buildx-action
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
       - name: Login to GHCR
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -40,7 +40,7 @@ jobs:
 
       - name: Docker meta
         id: biblioteca # you'll use this in the next step
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           # list of Docker images to use as base name for tags
           images: ghcr.io/${{ github.repository }}
@@ -53,7 +53,7 @@ jobs:
             type=sha
 
       - name: Build and push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           platforms: linux/amd64,linux/arm64

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       - name: Prepare env
         run: |
@@ -31,7 +31,7 @@ jobs:
           chmod -R 777 .
 
       - name: Install Docker Compose
-        uses: docker/setup-compose-action@v1
+        uses: docker/setup-compose-action@v2
 
       - name: Run docker-compose up
         run: docker compose  -f docker-compose.yml -f docker-compose.test.yml up -d --build
@@ -60,7 +60,7 @@ jobs:
 
       - if: ${{ github.event_name == 'pull_request' }}
         name: Download previous coverage
-        uses: dawidd6/action-download-artifact@v11
+        uses: dawidd6/action-download-artifact@v21
         continue-on-error: true
         with:
           workflow: tests.yml # this file
@@ -70,13 +70,13 @@ jobs:
 
       - if: ${{ github.event_name != 'pull_request' }}
         name: Upload coverage
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: coverage-report
           path: coverage.xml
 
       - name: Coverage Report as Comment
-        uses: lucassabreu/comment-coverage-clover@main
+        uses: lucassabreu/comment-coverage-clover@v0.17.2
         if: ${{ github.event_name == 'pull_request' }}
         with:
           file: coverage.xml


### PR DESCRIPTION
Renovate keeps major updates behind dependency-dashboard approval (`"major": { "dependencyDashboardApproval": true }`), so every action in `.github/workflows/` had drifted one or more majors behind. This catches all of them up in one go.

## Updates

| Action | File(s) | From | To |
| --- | --- | --- | --- |
| `actions/checkout` | doc.yml | v4 | v7 |
| `actions/checkout` | tests.yml, docker-publish.yml | v5 | v7 |
| `actions/setup-go` | doc.yml | v5 | v7 |
| `actions/upload-artifact` | tests.yml | v4 | v7 |
| `dawidd6/action-download-artifact` | tests.yml | v11 | v21 |
| `docker/setup-compose-action` | tests.yml | v1 | v2 |
| `docker/setup-qemu-action` | docker-publish.yml | v3 | v4 |
| `docker/setup-buildx-action` | docker-publish.yml | v3 | v4 |
| `docker/login-action` | docker-publish.yml | v3 | v4 |
| `docker/metadata-action` | docker-publish.yml | v5 | v6 |
| `docker/build-push-action` | docker-publish.yml | v6 | v7 |
| `lucassabreu/comment-coverage-clover` | tests.yml | `@main` | v0.17.2 |

`peaceiris/actions-hugo@v3` and `peaceiris/actions-gh-pages@v4` are already on their latest majors and are untouched.

## Breaking changes reviewed

Almost all of these majors are the same change — **Node 20 → Node 24 runtime + ESM**, requiring Actions Runner ≥ 2.327.1. GitHub-hosted `ubuntu-latest` satisfies that and no self-hosted runners are used. The non-runtime breaking changes don't apply here:

- **checkout v6** — credentials persisted to a separate file instead of `.git/config`. No step does authenticated git after checkout (`actions-gh-pages` uses its own `github_token`).
- **checkout v7** — blocks fork PR checkout under `pull_request_target` / `workflow_run`. Neither trigger is used.
- **setup-go v6** — sets `GOTOOLCHAIN=local`. `doc/go.mod` declares `go 1.22` and the workflow installs `go-version: stable`, so the installed toolchain is always newer.
- **setup-buildx v4** — removes deprecated inputs/outputs. No inputs are passed and the step's `id: buildx` is never referenced.
- **build-push v7** — removes deprecated `DOCKER_BUILD_NO_SUMMARY` / `DOCKER_BUILD_EXPORT_RETENTION_DAYS`. Neither is set.
- **metadata-action v6** — list inputs now preserve `#` inside values. The `tags:` block contains no `#`.
- **download-artifact v12→v21** — deps/ESM/Node 24 plus "download artifacts in creation order"; no input contract change. It reads via `@actions/artifact` v6, the same v4-era backend `upload-artifact@v4..v7` writes to, so downloading `main`'s existing v4-uploaded coverage artifact still works during rollout.

No workflow logic changed — these are version-string edits only.

## Bonus: pin the coverage-comment action

`lucassabreu/comment-coverage-clover` was pinned to `@main`, a moving branch, in a step that runs with `pull-requests: write`. Pinned to `v0.17.2`, which is the current head of `main` — behaviour is unchanged today, but the ref no longer moves under us and Renovate can now track it.

## Verification

- `tests.yml` runs on this PR: watch that checkout, `setup-compose-action@v2` and the docker-compose pipeline pass, that the "Download previous coverage" step actually finds the artifact (it's `continue-on-error`, so check the log rather than the tick), and that the coverage comment shows a base comparison.
- `docker-publish.yml` and `doc.yml` don't run on `pull_request` — the docker action majors and the Hugo build are only exercised on the push to `main` after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)